### PR TITLE
Enabled debugging for Android webviews.

### DIFF
--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -247,7 +247,9 @@ class WebViewFullState extends State<WebViewFull> with WidgetsBindingObserver {
       },
     );
 
-    //AndroidInAppWebViewController.setWebContentsDebuggingEnabled(true);
+    if (Platform.isAndroid) {
+        AndroidInAppWebViewController.setWebContentsDebuggingEnabled(true);
+    }
   }
 
   @override


### PR DESCRIPTION
 Allows for debugging using chrome via a connected PC. Useful when developing web scripts designed to work inside TornPDA

More information:

https://developer.chrome.com/docs/devtools/remote-debugging/webviews/