### PR TITLE
Fixing build issue for security domain config. 

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,6 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">torn.com</domain>
         <!-- 10.0.2.2 localhost for the emulator (cloud functions tests using http)-->
-        <domain>10.0.2.2</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Error was:

torn-pda/android/app/src/main/res/xml/network_security_config.xml:6: Error: Missing includeSubdomains attribute [NetworkSecurityConfig]
        <domain>10.0.2.2</domain>
         ~~~~~~

   Explanation for issues of type NetworkSecurityConfig:
   Ensures that a <network-security-config> file, which is pointed to by an
   android:networkSecurityConfig attribute in the manifest file, is valid

   https://developer.android.com/preview/features/security-config.html

1 errors, 0 warnings

FAILURE: Build failed with an exception.