### PR TITLE
Rework spies to support ID-based lookups

### DIFF
--- a/lib/models/chaining/tornstats/tornstats_spies_model.dart
+++ b/lib/models/chaining/tornstats/tornstats_spies_model.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:torn_pda/models/chaining/yata/yata_spy_model.dart';
+
 TornStatsSpiesModel tornStatsSpiesModelFromJson(String str) => TornStatsSpiesModel.fromJson(json.decode(str));
 
 String tornStatsSpiesModelToJson(TornStatsSpiesModel data) => json.encode(data.toJson());
@@ -108,6 +110,25 @@ class SpyElement {
         "player_level": playerLevel,
         "player_faction": playerFaction,
       };
+
+  YataSpyModel toYataModel() {
+    return YataSpyModel(
+      strength: strength,
+      speed: speed,
+      defense: defense,
+      dexterity: dexterity,
+      total: total,
+      strengthTimestamp: timestamp,
+      speedTimestamp: timestamp,
+      defenseTimestamp: timestamp,
+      dexterityTimestamp: timestamp,
+      totalTimestamp: timestamp,
+      update: timestamp,
+      targetName: playerName,
+      targetId: playerId,
+      targetFactionName: playerFaction,
+    );
+  }
 }
 
 class User {

--- a/lib/models/chaining/yata/yata_spy_model.dart
+++ b/lib/models/chaining/yata/yata_spy_model.dart
@@ -23,6 +23,7 @@ class YataSpyModel {
     this.totalTimestamp,
     this.update,
     this.targetName,
+    this.targetId,
     this.targetFactionName,
     this.targetFactionId,
   });
@@ -39,6 +40,7 @@ class YataSpyModel {
   int? totalTimestamp;
   int? update;
   String? targetName;
+  String? targetId;
   String? targetFactionName;
   int? targetFactionId;
 
@@ -55,6 +57,7 @@ class YataSpyModel {
     totalTimestamp: json["total_timestamp"],
     update: json["update"],
     targetName: json["target_name"],
+    targetId: json["target_id"],
     targetFactionName: json["target_faction_name"],
     targetFactionId: json["target_faction_id"],
   );
@@ -72,6 +75,7 @@ class YataSpyModel {
     "total_timestamp": totalTimestamp,
     "update": update,
     "target_name": targetName,
+    "target_id": targetId,
     "target_faction_name": targetFactionName,
     "target_faction_id": targetFactionId,
   };

--- a/lib/providers/retals_controller.dart
+++ b/lib/providers/retals_controller.dart
@@ -384,44 +384,29 @@ class RetalsController extends GetxController {
 
     // Find the spy based in the current selected spy source
     if (spyController.spiesSource == SpiesSource.yata) {
-      for (final YataSpyModel spy in spyController.yataSpies) {
-        if (spy.targetName == retal.name) {
-          assignYataSpy(retal, spy);
-
+      final spy = spyController.getYataSpy(userId: retal.retalId.toString(), name: retal.name);
+      if (spy != null) {
+        assignYataSpy(retal, spy);
+        spyFound = true;
+      } else if (spyController.allowMixedSpiesSources) {
+        // Check alternate source of spies if we allow mixed sources
+        final altSpy = spyController.getTornStatsSpy(userId: retal.retalId.toString());
+        if (altSpy != null) {
+          assignTornStatsSpy(retal, altSpy);
           spyFound = true;
-          break;
         }
       }
     } else if (spyController.spiesSource == SpiesSource.tornStats) {
-      for (final SpyElement spy in spyController.tornStatsSpies.spies) {
-        if (spy.playerName == retal.name) {
-          assignTornStatsSpy(retal, spy);
-
+      final spy = spyController.getTornStatsSpy(userId: retal.retalId.toString());
+      if (spy != null) {
+        assignTornStatsSpy(retal, spy);
+        spyFound = true;
+      } else if (spyController.allowMixedSpiesSources) {
+        // Check alternate source of spies if we allow mixed sources
+        final altSpy = spyController.getYataSpy(userId: retal.retalId.toString(), name: retal.name);
+        if (altSpy != null) {
+          assignYataSpy(retal, altSpy);
           spyFound = true;
-          break;
-        }
-      }
-    }
-
-    // If we didn't find a spy and we allow mixed spies sources, search in the other source
-    if (spyController.allowMixedSpiesSources && !spyFound) {
-      if (spyController.spiesSource == SpiesSource.tornStats) {
-        for (final YataSpyModel spy in spyController.yataSpies) {
-          if (spy.targetName == retal.name) {
-            assignYataSpy(retal, spy);
-
-            spyFound = true;
-            break;
-          }
-        }
-      } else if (spyController.spiesSource == SpiesSource.yata) {
-        for (final SpyElement spy in spyController.tornStatsSpies.spies) {
-          if (spy.playerName == retal.name) {
-            assignTornStatsSpy(retal, spy);
-
-            spyFound = true;
-            break;
-          }
         }
       }
     }

--- a/lib/providers/spies_controller.dart
+++ b/lib/providers/spies_controller.dart
@@ -232,4 +232,27 @@ class SpiesController extends GetxController {
 
     return false;
   }
+
+  // Allow name lookup for YATA as old spies will be missing the ID
+  YataSpyModel? getYataSpy({required String userId, String? name}) {
+    if (name == null) {
+      return _yataSpies.firstWhereOrNull((spy) => spy.targetId == userId);
+    } else {
+      YataSpyModel? namedResponse;
+      // This looks weird, but it's to ensure that the ID will always take priority. Either an ID match is found,
+      // or the last matching name is returned. This is to ensure that if a user changes names with someone,
+      // their spies will not be mixed unless the spy data is missing their ID.
+      return _yataSpies.firstWhereOrNull((spy) {
+            if (spy.targetName == name) {
+              namedResponse = spy;
+            }
+            return spy.targetId == userId;
+          }) ??
+          namedResponse;
+    }
+  }
+
+  SpyElement? getTornStatsSpy({required String userId}) {
+    return _tornStatsSpies.spies.firstWhereOrNull((spy) => spy.playerId == userId);
+  }
 }

--- a/lib/providers/war_controller.dart
+++ b/lib/providers/war_controller.dart
@@ -922,46 +922,31 @@ class WarController extends GetxController {
       _deleteSpiedStats(member);
     }
 
-    // Find the spy based in the current selected spy source
+        // Find the spy based in the current selected spy source
     if (spyController.spiesSource == SpiesSource.yata) {
-      for (final YataSpyModel spy in spyController.yataSpies) {
-        if (spy.targetName == member.name) {
-          assignYataSpy(member, spy);
-
+      final spy = spyController.getYataSpy(userId: member.memberId.toString(), name: member.name);
+      if (spy != null) {
+        assignYataSpy(member, spy);
+        spyFound = true;
+      } else if (spyController.allowMixedSpiesSources) {
+        // Check alternate source of spies if we allow mixed sources
+        final altSpy = spyController.getTornStatsSpy(userId: member.memberId.toString());
+        if (altSpy != null) {
+          assignTornStatsSpy(member, altSpy);
           spyFound = true;
-          break;
         }
       }
     } else if (spyController.spiesSource == SpiesSource.tornStats) {
-      for (final SpyElement spy in spyController.tornStatsSpies.spies) {
-        if (spy.playerName == member.name) {
-          assignTornStatsSpy(member, spy);
-
+      final spy = spyController.getTornStatsSpy(userId: member.memberId.toString());
+      if (spy != null) {
+        assignTornStatsSpy(member, spy);
+        spyFound = true;
+      } else if (spyController.allowMixedSpiesSources) {
+        // Check alternate source of spies if we allow mixed sources
+        final altSpy = spyController.getYataSpy(userId: member.memberId.toString(), name: member.name);
+        if (altSpy != null) {
+          assignYataSpy(member, altSpy);
           spyFound = true;
-          break;
-        }
-      }
-    }
-
-    // If we didn't find a spy and we allow mixed spies sources, search in the other source
-    if (spyController.allowMixedSpiesSources && !spyFound) {
-      if (spyController.spiesSource == SpiesSource.tornStats) {
-        for (final YataSpyModel spy in spyController.yataSpies) {
-          if (spy.targetName == member.name) {
-            assignYataSpy(member, spy);
-
-            spyFound = true;
-            break;
-          }
-        }
-      } else if (spyController.spiesSource == SpiesSource.yata) {
-        for (final SpyElement spy in spyController.tornStatsSpies.spies) {
-          if (spy.playerName == member.name) {
-            assignTornStatsSpy(member, spy);
-
-            spyFound = true;
-            break;
-          }
         }
       }
     }


### PR DESCRIPTION
I'm less sure about this one, I may have got carried away a little. 
- Store User ID in YATA spies
- Lookup by User ID for both sets of spies, preventing issues with data when a user changes name or the TS API doesn't include a username (fix for #203)
- Add method to convert TS model spies to YATA model spies for simplicity
- Add lookup functions to the spies controller, supporting username for YATA for old spy data missing the ID
- Rewrite relevant sections to use the new lookup functions
