### PR TITLE
Bazaar Auto Price - prevent prices below $2

### DIFF
--- a/userscripts/Bazaar Auto Price (Torn PDA).js
+++ b/userscripts/Bazaar Auto Price (Torn PDA).js
@@ -39,7 +39,7 @@ async function lmp(itemID) {
 	const prices = await torn_api(`market.${itemID}.bazaar`)
 	if (prices.error) { APIERROR = true; return 'API key error' }
 	const lowest_market_price = prices['bazaar'][0].cost
-	return lowest_market_price - 5
+	return Math.max(lowest_market_price - 5, 2)
 }
 
 // HACK to simulate input value change


### PR DESCRIPTION
Fixes a rare issue that sets the price to negatives when the current lowest item is below $5.

Deliberately $2 instead of $1, as $1 is reserved for black-friday sales and won't sell quick (like the purpose of this script)