### PR TITLE
Update Chat Highlight

### DIFF
--- a/lib/pages/settings/settings_browser.dart
+++ b/lib/pages/settings/settings_browser.dart
@@ -21,6 +21,7 @@ import 'package:torn_pda/providers/theme_provider.dart';
 import 'package:torn_pda/providers/userscripts_provider.dart';
 import 'package:torn_pda/providers/webview_provider.dart';
 import 'package:torn_pda/utils/shared_prefs.dart';
+import 'package:torn_pda/widgets/settings/chat_highlight_word_dialog.dart';
 import 'package:torn_pda/widgets/webviews/pda_browser_icon.dart';
 
 class SettingsBrowserPage extends StatefulWidget {
@@ -970,7 +971,7 @@ class SettingsBrowserPageState extends State<SettingsBrowserPage> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
-              const Text("Highlight own name in chat"),
+              const Text("Highlight messages in chat"),
               Switch(
                 value: _settingsProvider.highlightChat,
                 onChanged: (value) {
@@ -986,37 +987,37 @@ class SettingsBrowserPageState extends State<SettingsBrowserPage> {
         ),
         if (_highlightChat)
           Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              GestureDetector(
-                onTap: () {
-                  _showColorPickerChat(context);
-                },
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 0, 35, 10),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      const Text("Choose highlight colour"),
-                      Container(
-                        width: 25,
-                        height: 25,
-                        color: _highlightColor,
-                      )
-                    ],
-                  ),
+              Padding(
+                padding: const EdgeInsets.only(left: 20, top: 10, right: 20, bottom: 5),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    const Flexible(
+                      child: Text(
+                        "Select words to highlight",
+                      ),
+                    ),
+                    ElevatedButton(
+                        child: const Icon(Icons.drive_file_rename_outline_sharp),
+                        onPressed: () => _showHighlightSelectorChat(context)),
+                  ],
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Text(
-                  "The sender's name will appear darker "
-                  'to improve readability',
-                  style: TextStyle(
-                    color: Colors.grey[600],
-                    fontSize: 12,
-                    fontStyle: FontStyle.italic,
-                  ),
+                padding: const EdgeInsets.only(left: 20, top: 10, right: 20, bottom: 5),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    const Flexible(
+                      child: Text(
+                        "Select highlight color",
+                      ),
+                    ),
+                    ElevatedButton(
+                        child: Icon(Icons.palette, color: _highlightColor.withAlpha(255)),
+                        onPressed: () => _showColorPickerChat(context)),
+                  ],
                 ),
               ),
             ],
@@ -1920,6 +1921,10 @@ class SettingsBrowserPageState extends State<SettingsBrowserPage> {
         );
       },
     );
+  }
+
+  void _showHighlightSelectorChat(BuildContext context) {
+    showDialog(useRootNavigator: false, context: context, builder: (c) => ChatHighlightAddWordsDialog());
   }
 
   void _showColorPickerChat(BuildContext context) {

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -369,6 +369,14 @@ class SettingsProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  var _highlightWordList = <String>[];
+  List<String> get highlightWordList => _highlightWordList;
+  set changeHighlightWordList(List<String> value) {
+    _highlightWordList = value;
+    Prefs().setHighlightWordList(_highlightWordList);
+    notifyListeners();
+  }
+
   var _removeAirplane = false;
   bool get removeAirplane => _removeAirplane;
   set changeRemoveAirplane(bool value) {
@@ -830,6 +838,7 @@ class SettingsProvider extends ChangeNotifier {
 
     _highlightChat = await Prefs().getHighlightChat();
     _highlightColor = await Prefs().getHighlightColor();
+    _highlightWordList = await Prefs().getHighlightWordList();
 
     _removeAirplane = await Prefs().getRemoveAirplane();
 

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -198,6 +198,7 @@ class Prefs {
   final String _kShowAchievedAwards = "pda_showAchievedAwards";
   final String _kHiddenAwardCategories = "pda_hiddenAwardCategories";
   final String _kHighlightChat = "pda_highlightChat";
+  final String _kHighlightChatWordsList = "pda_highlightChatWordsList";
   final String _kHighlightColor = "pda_highlightColor";
   final String _kUserScriptsEnabled = "pda_userScriptsEnabled";
   final String _kUserScriptsNotifyUpdates = "pda_userScriptsNotifyUpdates";
@@ -2351,6 +2352,16 @@ class Prefs {
   Future<bool> setHighlightChat(bool value) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     return prefs.setBool(_kHighlightChat, value);
+  }
+
+  Future<List<String>> getHighlightWordList() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_kHighlightChatWordsList) ?? const [];
+  }
+
+  Future<bool> setHighlightWordList(List<String> value) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.setStringList(_kHighlightChatWordsList, value);
   }
 
   Future<int> getHighlightColor() async {

--- a/lib/widgets/settings/chat_highlight_word_dialog.dart
+++ b/lib/widgets/settings/chat_highlight_word_dialog.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:torn_pda/providers/settings_provider.dart';
+
+class ChatHighlightAddWordsDialog extends StatefulWidget {
+  @override
+  State<ChatHighlightAddWordsDialog> createState() => ChatHighlightAddWordsDialogState();
+}
+
+class ChatHighlightAddWordsDialogState extends State<ChatHighlightAddWordsDialog> {
+  final TextEditingController _addChatHighlightTextController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  late SettingsProvider _settingsProvider;
+  List<String> _wordList = [];
+  bool _enableButton = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _settingsProvider = Provider.of<SettingsProvider>(context, listen: false);
+    _wordList = _settingsProvider.highlightWordList;
+  }
+
+  @override
+  void dispose() {
+    _addChatHighlightTextController.dispose();
+    _formKey.currentState?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Select words to highlight'),
+      content: Container(
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+          child: SingleChildScrollView(
+              child: Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      Text(
+                          "Your username will be highlighted by default, so you do not need to add it here. "
+                          "Keep in mind that the highlights are a simple substring check - if you add 'cat', "
+                          "it would match 'catastrophe'.",
+                          style: TextStyle(
+                            fontSize: 11,
+                            fontStyle: FontStyle.italic,
+                            color: Colors.grey[600],
+                          )),
+                      const SizedBox(height: 15),
+                      Container(
+                        child: Row(children: [
+                          Flexible(
+                              child: TextFormField(
+                            controller: _addChatHighlightTextController,
+                            style: const TextStyle(fontSize: 14),
+                            maxLength: 30,
+                            decoration: InputDecoration(hintText: "Enter a word to highlight"),
+                            autovalidateMode: AutovalidateMode.onUserInteraction,
+                            validator: (s) {
+                              if (s is! String || s.trim().isEmpty) return 'Please enter a valid word';
+                              if (_wordList.contains(s.trim().toLowerCase())) return 'Word already added';
+                              return null;
+                            },
+                            textInputAction: TextInputAction.unspecified,
+                            onChanged: (s) => setState(() => _enableButton = _formKey.currentState!.validate()),
+                            onFieldSubmitted: (s) {
+                              if (_formKey.currentState!.validate()) {
+                                setState(() {
+                                _wordList.add(s.toLowerCase());
+                                _addChatHighlightTextController.text = "";
+                                _settingsProvider.changeHighlightWordList = _wordList;
+                              });
+                              }
+                            },
+                          )),
+                          IconButton(
+                              icon: const Icon(Icons.add_circle),
+                              onPressed: _enableButton
+                                  ? () {
+                                      if (!_formKey.currentState!.validate()) return;
+                                      setState(() {
+                                        _wordList.add(_addChatHighlightTextController.text.toLowerCase());
+                                        _addChatHighlightTextController.text = "";
+                                        _settingsProvider.changeHighlightWordList = _wordList;
+                                      });
+                                    }
+                                  : null)
+                        ]),
+                        margin: EdgeInsets.only(right: 10),
+                      ),
+                      SingleChildScrollView(
+                        child: Column(
+                            children: _wordList
+                                .map((s) => Container(
+                                    child: Row(
+                                      children: [
+                                        Expanded(child: Text(s), flex: 1),
+                                        IconButton(
+                                            onPressed: () => setState(() {
+                                                  _wordList.remove(s);
+                                                  _settingsProvider.changeHighlightWordList = _wordList;
+                                                }),
+                                            icon: const Icon(Icons.delete, color: Colors.red))
+                                      ],
+                                    ),
+                                    decoration: BoxDecoration(
+                                      border: Border.all(color: Colors.grey[300]!),
+                                      borderRadius: BorderRadius.circular(5),
+                                    ),
+                                    padding: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+                                    margin: EdgeInsets.symmetric(vertical: 5)))
+                                .toList()),
+                      )
+                    ],
+                  )))),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Got it'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget wordCards() {
+    return ListView(
+      shrinkWrap: true,
+      children: _wordList
+          .map<Widget>((s) => Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+                Text(s),
+                IconButton(
+                    onPressed: () => setState(() {
+                          _wordList.remove(s);
+                          _settingsProvider.changeHighlightWordList = _wordList;
+                        }),
+                    icon: const Icon(Icons.delete))
+              ]))
+          .toList(),
+    );
+  }
+}

--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -1,6 +1,7 @@
 // Dart imports:
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
@@ -2012,12 +2013,15 @@ class WebViewFullState extends State<WebViewFull> with WidgetsBindingObserver {
     final intColor = Color(_settingsProvider.highlightColor);
     final background = 'rgba(${intColor.red}, ${intColor.green}, ${intColor.blue}, ${intColor.opacity})';
     final senderColor = 'rgba(${intColor.red}, ${intColor.green}, ${intColor.blue}, 1)';
-    final String hlMap =
-        '[ { name: "${_userProvider!.basic!.name}", highlight: "$background", sender: "$senderColor" } ]';
+    final String hlMap = '[ "${_userProvider!.basic!.name}", ...${jsonEncode(_settingsProvider.highlightWordList)} ]';
+    final String css = chatHighlightCSS(background: background, senderColor: senderColor);
 
     if (_settingsProvider.highlightChat) {
       webView!.evaluateJavascript(
-        source: chatHighlightJS(highlightMap: hlMap),
+        source: chatHighlightJS(highlights: hlMap),
+      );
+      webView!.injectCSSCode(
+        source: css,
       );
     }
   }

--- a/lib/widgets/webviews/webview_panic.dart
+++ b/lib/widgets/webviews/webview_panic.dart
@@ -1,5 +1,6 @@
 // Dart imports:
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 // Package imports:
@@ -240,12 +241,16 @@ class WebViewPanicState extends State<WebViewPanic> {
     final intColor = Color(_settingsProvider.highlightColor);
     final background = 'rgba(${intColor.red}, ${intColor.green}, ${intColor.blue}, ${intColor.opacity})';
     final senderColor = 'rgba(${intColor.red}, ${intColor.green}, ${intColor.blue}, 1)';
-    final String hlMap = '[ { name: "${_userProv!.basic!.name}", highlight: "$background", sender: "$senderColor" } ]';
+    final String hlMap = '[ "${_userProv!.basic!.name}", ...${jsonEncode(_settingsProvider.highlightWordList)} ]';
+    final String css = chatHighlightCSS(background: background, senderColor: senderColor);
 
     if (_settingsProvider.highlightChat) {
       _webViewController!.runJavascript(
-        chatHighlightJS(highlightMap: hlMap),
+        chatHighlightJS(highlights: hlMap),
       );
+      _webViewController!.runJavascript("const x = document.createElement('style');"
+          "x.innerHTML = `$css`;"
+          "document.head.appendChild(x);");
     }
   }
 


### PR DESCRIPTION
Fixes for chat 2.0, allow users to add custom highlights, inject CSS separately from JS

Changes:
- Allow users to add their own highlights, rather than just username. Highlights are case- and whitespace-insensitive (`Cat` will match `cATastrophe`, for example).
- New widget to allow users to add/manage the words they wish to be highlighted, with new option in settings to open widget
- Added prefs to save the highlighted words
- New button for the color picker to match the word selector button - if this isn't desired, definitely change it back
- Custom CSS for the highlights which are injected directly into the webview where possible, else a style element is created

Fixes #223 