### PR TITLE
Add headers parameter to PDA_httpGet JS and Dart handlers

### DIFF
--- a/lib/utils/js_handlers.dart
+++ b/lib/utils/js_handlers.dart
@@ -7,6 +7,7 @@ String handler_flutterPlatformReady() {
     if(typeof __PDA_platformReadyPromise === 'undefined') {
         __PDA_platformReadyPromise = new Promise(resolve => {
             //console.log("Handler: pdaHandler_platformReady");
+            if (window.flutter_inappwebview?._platformReady) return resolve();
             window.addEventListener("flutterInAppWebViewPlatformReady", resolve);
         });
     }

--- a/lib/utils/js_handlers.dart
+++ b/lib/utils/js_handlers.dart
@@ -16,6 +16,9 @@ String handler_flutterPlatformReady() {
 String handler_pdaAPI() {
   return '''
     // Performs a GET request to the provided URL
+    // The expected arguments are:
+    //     url
+    //     headers - Object with key, value string pairs (optional for backwards compatibility)
     // Returns a promise for a response object that has these properties:
     //     responseHeaders - String, with CRLF line terminators.
     //     responseText
@@ -28,8 +31,13 @@ String handler_pdaAPI() {
     // 
     //
     // Example call:
+    // 
     //
-    // PDA_httpGet('https://api.example.com/data').then(response => {
+    // let url = 'https://api.example.com/data';
+    // let headers = {
+    //     "Content-Type": "application/json"
+    // }
+    // PDA_httpGet(url, headers).then(response => {
     //     console.log(response);
     // }).catch(error => {
     //     console.error(error);
@@ -40,7 +48,8 @@ String handler_pdaAPI() {
         var loadedPdaApiGetUrls = {};
     }
 
-    async function PDA_httpGet(url) {
+    async function PDA_httpGet(url, headers = {}) {
+        let parameters = `\${url}+\${JSON.stringify(headers)}`;
         let now = Date.now();
 
         // If this URL was loaded less than a second ago, return immediately
@@ -56,7 +65,7 @@ String handler_pdaAPI() {
         console.log("Handler: pdaHandler_ApiGet");
         await __PDA_platformReadyPromise;
           
-        return window.flutter_inappwebview.callHandler("PDA_httpGet", url);
+        return window.flutter_inappwebview.callHandler("PDA_httpGet", url, headers);
     }
 
 
@@ -227,7 +236,9 @@ String handler_GM() {
                         "Invalid method passed to GM.xmlHttpRequest"
                     );
                 if (!method || method.toLowerCase() === "get") {
-                    return await PDA_httpGet(url)
+		    const h = headers ?? {};
+		    h["X-GMforPDA"] = "Sent from PDA via GMforPDA";
+                    return await PDA_httpGet(url, h ?? {})
                         .then(onload ?? ((x) => x))
                         .catch(onerror ?? ((e) => console.error(e)));
                 } else if (method.toLowerCase() === "post") {

--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -1805,7 +1805,7 @@ class WebViewFullState extends State<WebViewFull> with WidgetsBindingObserver {
     webView.addJavaScriptHandler(
       handlerName: 'PDA_httpGet',
       callback: (args) async {
-        final http.Response resp = await http.get(WebUri(args[0]));
+        final http.Response resp = await http.get(WebUri(args[0], headers: Map<String, String>.from(args[1])));
         return _makeScriptApiResponse(resp);
       },
     );

--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -1805,7 +1805,7 @@ class WebViewFullState extends State<WebViewFull> with WidgetsBindingObserver {
     webView.addJavaScriptHandler(
       handlerName: 'PDA_httpGet',
       callback: (args) async {
-        final http.Response resp = await http.get(WebUri(args[0], headers: Map<String, String>.from(args[1])));
+        final http.Response resp = await http.get(WebUri(args[0]), headers: Map<String, String>.from(args[1]));
         return _makeScriptApiResponse(resp);
       },
     );

--- a/userscripts/GMforPDA.user.js
+++ b/userscripts/GMforPDA.user.js
@@ -119,7 +119,9 @@ window.GM = {
 					"Invalid method passed to GM.xmlHttpRequest"
 				);
 			if (!method || method.toLowerCase() === "get") {
-				return await PDA_httpGet(url)
+				const h = headers ?? {};
+				h["X-GMforPDA"] = "Sent from PDA via GMforPDA";
+				return await PDA_httpGet(url, h ?? {})
 					.then(onload ?? ((x) => x))
 					.catch(onerror ?? ((e) => console.error(e)));
 			} else if (method.toLowerCase() === "post") {

--- a/userscripts/TornPDA_API.js
+++ b/userscripts/TornPDA_API.js
@@ -1,12 +1,15 @@
 // Performs a GET request to the provided URL
+// The expected arguments are:
+//     url
+//     headers - Object with key, value string pairs (optional for backwards compatibility)
 // Returns a promise for a response object that has these properties:
 //     responseHeaders - String, with CRLF line terminators.
 //     responseText
 //     status
 //     statusText
-async function PDA_httpGet(url) {
+async function PDA_httpGet(url, headers = {}) {
     await __PDA_platformReadyPromise;
-    return window.flutter_inappwebview.callHandler("PDA_httpGet", url);
+    return window.flutter_inappwebview.callHandler("PDA_httpGet", url, headers);
 }
 
 // Performs a POST request to the provided URL


### PR DESCRIPTION
The `PDA_httpGet` Dart handlers and JS function were missing the header parameter. For backwards compatibility, the header parameter has been set to default to an empty map/object to prevent breaking changes for scripts that don't use a header.

[Kwack-Kwack/GMforPDA](https://github.com/Kwack-Kwack/GMforPDA/) would also have to be updated to support this header too though.