### PR TITLE
Mock ViolentMonkey injection on GreasyFork

### DIFF
--- a/lib/utils/js_snippets.dart
+++ b/lib/utils/js_snippets.dart
@@ -1452,3 +1452,22 @@ String barsDoubleClickRedirect() {
     })();
   ''';
 }
+
+String greasyForkMockVM(String scripts) {
+  // Imitate ViolentMonkey on GreasyFork for identifying version numbers and removing the install warning
+  return """
+    ((PDA_script_list) => {
+	const Violentmonkey = {};
+	Object.defineProperty(Violentmonkey, "getVersion", {
+		value: async () => null,
+	});
+	Object.defineProperty(Violentmonkey, "isInstalled", {
+		// namespace is not used (yet)
+		value: async (name, _) => PDA_script_list.find(s => s.name === name)?.version || null,
+	});
+	Object.defineProperty(window.external, "Violentmonkey", {
+		value: Violentmonkey,
+	});
+})($scripts);
+  """;
+}

--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -1379,6 +1379,12 @@ class WebViewFullState extends State<WebViewFull> with WidgetsBindingObserver {
               // Prevents issue if webView is closed too soon, in between the 'mounted' check and the rest of
               // the checks performed in this method
             }
+            // Needs to be done as early as possible
+            if (uri?.host == "greasyfork.org") {
+              c.evaluateJavascript(
+                  source: greasyForkMockVM(jsonEncode(
+                      _userScriptsProvider.userScriptList.map((s) => ({"name": s.name, "version": s.version})).toList())));
+            }
           },
           onProgressChanged: (c, progress) async {
             if (!mounted) return;


### PR DESCRIPTION
Mocks ViolentMonkey's injection into GreasyFork:
- Removes prompt to install a script manager
- Greasyfork will now dynamically change the install button:
  - Show the standard install button if the user hasn't installed the script
  - Show `Update to version ${versionString}` when the remote version is more up-to-date than the installed version
  - Show `Reinstall version ${versionString}` when the remote version matches the installed version

Currently ignores the namespace, since PDA script names must be unique. 

![Screenshot of the Reinstall Version button](https://i.imgur.com/naK5Tcw.png)