### PR TITLE
fix: respect user selections when importing data

### DIFF
--- a/lib/widgets/settings/backup/backup_import_widget.dart
+++ b/lib/widgets/settings/backup/backup_import_widget.dart
@@ -9,12 +9,14 @@ class BackupImportWidget extends StatefulWidget {
   final OwnProfileBasic userProfile;
   final Map<String, dynamic> serverPrefs;
   final Function(BackupPrefs, bool) overwritteCallback;
+  final Function(BackupPrefs, bool) toggleBackupSelection;
   final bool fromShareDialog;
 
   const BackupImportWidget({
     required this.userProfile,
     required this.serverPrefs,
     required this.overwritteCallback,
+    required this.toggleBackupSelection,
     this.fromShareDialog = false,
   });
 
@@ -60,19 +62,18 @@ class BackupImportWidgeState extends State<BackupImportWidget> {
         Padding(
           padding: const EdgeInsets.fromLTRB(8, 5, 8, 0),
           child: CheckboxListTile(
-            checkColor: Colors.white,
-            activeColor: Colors.blueGrey,
-            value: _selectedItems.contains("shortcuts"),
-            title: const Text("Shorcuts"),
-            subtitle: Text("Shortcuts list and settings", style: TextStyle(fontSize: 12)),
-            onChanged: (value) {
-              setState(() {
-                _selectedItems.contains("shortcuts")
-                    ? _selectedItems.remove("shortcuts")
-                    : _selectedItems.add("shortcuts");
-              });
-            },
-          ),
+              checkColor: Colors.white,
+              activeColor: Colors.blueGrey,
+              value: _selectedItems.contains("shortcuts"),
+              title: const Text("Shorcuts"),
+              subtitle: Text("Shortcuts list and settings", style: TextStyle(fontSize: 12)),
+              onChanged: (value) {
+                final bool shouldEnable = !_selectedItems.contains("shortcuts");
+                setState(() {
+                  shouldEnable ? _selectedItems.add("shortcuts") : _selectedItems.remove("shortcuts");
+                });
+                widget.toggleBackupSelection(BackupPrefs.shortcuts, shouldEnable);
+              }),
         ),
         if (_selectedItems.contains("shortcuts"))
           Padding(
@@ -149,12 +150,11 @@ class BackupImportWidgeState extends State<BackupImportWidget> {
                   contentPadding: const EdgeInsets.all(10),
                 );
               }
-
+              final bool shouldEnable = !_selectedItems.contains("userscripts");
               setState(() {
-                _selectedItems.contains("userscripts")
-                    ? _selectedItems.remove("userscripts")
-                    : _selectedItems.add("userscripts");
+                shouldEnable ? _selectedItems.add("userscripts") : _selectedItems.remove("userscripts");
               });
+              widget.toggleBackupSelection(BackupPrefs.userscripts, shouldEnable);
             },
           ),
         ),
@@ -219,9 +219,11 @@ class BackupImportWidgeState extends State<BackupImportWidget> {
             title: const Text("Targets"),
             subtitle: Text("Targets list and notes", style: TextStyle(fontSize: 12)),
             onChanged: (value) {
+              final bool shouldEnable = !_selectedItems.contains("targets");
               setState(() {
-                _selectedItems.contains("targets") ? _selectedItems.remove("targets") : _selectedItems.add("targets");
+                shouldEnable ? _selectedItems.add("targets") : _selectedItems.remove("targets");
               });
+              widget.toggleBackupSelection(BackupPrefs.targets, shouldEnable);
             },
           ),
         ),

--- a/lib/widgets/settings/backup/backup_restore_button.dart
+++ b/lib/widgets/settings/backup/backup_restore_button.dart
@@ -23,11 +23,13 @@ class BackupRestoreButton extends StatefulWidget {
   final bool overwritteShortcuts;
   final bool overwritteUserscripts;
   final bool overwritteTargets;
+  final List<String> selectedItems;
 
   const BackupRestoreButton({
     required this.ownBackup,
     this.userProfile,
     this.otherData = const {},
+    required this.selectedItems,
     required this.overwritteShortcuts,
     required this.overwritteUserscripts,
     required this.overwritteTargets,
@@ -92,7 +94,7 @@ class BackupRestoreButtonState extends State<BackupRestoreButton> with TickerPro
       final activeShortcutsList = result["prefs"]["pda_activeShortcutsList"] as List?;
       final shortcutTile = result["prefs"]["pda_shortcutTile"];
       final shortcutMenu = result["prefs"]["pda_shortcutMenu"];
-      if (activeShortcutsList != null) {
+      if (activeShortcutsList != null && widget.selectedItems.contains("shortcuts")) {
         // Restore through the provider
         final shortcutsList = activeShortcutsList.map((item) => item as String).toList();
         final shortcutsProvider = context.read<ShortcutsProvider>();
@@ -106,7 +108,7 @@ class BackupRestoreButtonState extends State<BackupRestoreButton> with TickerPro
 
       // User scripts
       String? userscripts = result["prefs"]["pda_userScriptsList"];
-      if (userscripts != null) {
+      if (userscripts != null && widget.selectedItems.contains("userscripts")) {
         final userscriptsProvider = context.read<UserScriptsProvider>();
         userscriptsProvider.restoreScriptsFromServerSave(
           overwritte: widget.overwritteUserscripts,
@@ -116,7 +118,7 @@ class BackupRestoreButtonState extends State<BackupRestoreButton> with TickerPro
 
       // Shortcuts
       final targetsBackup = result["prefs"]["pda_targetsList"] as List?;
-      if (targetsBackup != null) {
+      if (targetsBackup != null && widget.selectedItems.contains("targets")) {
         // Restore through the provider
         final targetsList = targetsBackup.map((item) => item as String).toList();
         final targetsProvider = context.read<TargetsProvider>();

--- a/lib/widgets/settings/backup/backup_restore_dialog.dart
+++ b/lib/widgets/settings/backup/backup_restore_dialog.dart
@@ -96,6 +96,7 @@ class BackupRestoreDialogState extends State<BackupRestoreDialog> with TickerPro
                         userProfile: widget.userProfile,
                         serverPrefs: _serverPrefs,
                         overwritteCallback: _onOverwritteShortcutsChanged,
+                        toggleBackupSelection: _onToggleBackupSelection,
                       ),
                     ),
                   );
@@ -124,6 +125,7 @@ class BackupRestoreDialogState extends State<BackupRestoreDialog> with TickerPro
                     BackupRestoreButton(
                       ownBackup: true,
                       userProfile: widget.userProfile,
+                      selectedItems: _selectedItems,
                       overwritteShortcuts: _overwritteShortcuts,
                       overwritteUserscripts: _overwritteUserscripts,
                       overwritteTargets: _overwritteTargets,
@@ -178,6 +180,44 @@ class BackupRestoreDialogState extends State<BackupRestoreDialog> with TickerPro
         setState(() {
           _overwritteTargets = value;
         });
+        break;
+    }
+  }
+
+  void _onToggleBackupSelection(BackupPrefs pref, bool value) {
+    switch (pref) {
+      case BackupPrefs.shortcuts:
+        if (value) {
+          setState(() {
+            _selectedItems.add("shortcuts");
+          });
+        } else {
+          setState(() {
+            _selectedItems.remove("shortcuts");
+          });
+        }
+        break;
+      case BackupPrefs.userscripts:
+        if (value) {
+          setState(() {
+            _selectedItems.add("userscripts");
+          });
+        } else {
+          setState(() {
+            _selectedItems.remove("userscripts");
+          });
+        }
+        break;
+      case BackupPrefs.targets:
+        if (value) {
+          setState(() {
+            _selectedItems.add("targets");
+          });
+        } else {
+          setState(() {
+            _selectedItems.remove("targets");
+          });
+        }
         break;
     }
   }

--- a/lib/widgets/settings/backup/backup_share_dialog.dart
+++ b/lib/widgets/settings/backup/backup_share_dialog.dart
@@ -269,6 +269,7 @@ class BackupShareDialogState extends State<BackupShareDialog> with TickerProvide
                           BackupRestoreButton(
                             ownBackup: false,
                             otherData: _importedPrefs,
+                            selectedItems: _importedSelectedItems,
                             overwritteShortcuts: _overwritteShortcuts,
                             overwritteUserscripts: _overwritteUserscripts,
                             overwritteTargets: _overwritteTargets,
@@ -418,6 +419,7 @@ class BackupShareDialogState extends State<BackupShareDialog> with TickerProvide
       userProfile: widget.userProfile,
       serverPrefs: _importedPrefs,
       overwritteCallback: _onOverwritteShortcutsChanged,
+      toggleBackupSelection: _onToggleBackupSelection,
       fromShareDialog: true,
     );
   }
@@ -739,6 +741,44 @@ class BackupShareDialogState extends State<BackupShareDialog> with TickerProvide
         setState(() {
           _overwritteTargets = value;
         });
+        break;
+    }
+  }
+
+  void _onToggleBackupSelection(BackupPrefs pref, bool value) {
+    switch (pref) {
+      case BackupPrefs.shortcuts:
+        if (value) {
+          setState(() {
+            _importedSelectedItems.add("shortcuts");
+          });
+        } else {
+          setState(() {
+            _importedSelectedItems.remove("shortcuts");
+          });
+        }
+        break;
+      case BackupPrefs.userscripts:
+        if (value) {
+          setState(() {
+            _importedSelectedItems.add("userscripts");
+          });
+        } else {
+          setState(() {
+            _importedSelectedItems.remove("userscripts");
+          });
+        }
+        break;
+      case BackupPrefs.targets:
+        if (value) {
+          setState(() {
+            _importedSelectedItems.add("targets");
+          });
+        } else {
+          setState(() {
+            _importedSelectedItems.remove("targets");
+          });
+        }
         break;
     }
   }


### PR DESCRIPTION
This.... feels very messy to write, but for now it does the job.

**I don't think we should merge this until the Beta's storage is fixed**, just in case this breaks something. Not a good combo to mess with at the same time 😬. Haven't had anyone mention it to me, I assume it's gone mostly unnoticed so far.

Fix is for these checkboxes - they're currently doing nothing.
![RESTORE SETTINGS checkboxes that currently do nothing](https://i.imgur.com/C2ocHe6.png)