### PR TITLE
DX improvements for third-party script developers

### DIFF
--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -4257,7 +4257,7 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
   }
 
   Widget _cashWallet({bool? dense}) {
-    if (_user!.networth!["wallet"] != null) {
+    if (_user!.moneyOnHand != null) {
       final moneyFormat = NumberFormat("#,##0", "en_US");
       return Row(
         children: [
@@ -4274,7 +4274,7 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
           ),
           const SizedBox(width: 5),
           SelectableText(
-            '\$${moneyFormat.format(_user!.networth!["wallet"])}',
+            '\$${moneyFormat.format(_user!.moneyOnHand)}',
             style: TextStyle(
               fontSize: dense ? 13 : 14,
               fontWeight: dense ? FontWeight.bold : FontWeight.normal,
@@ -4762,10 +4762,16 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
     final moneySources = <Widget>[];
     final moneyQuantities = <Widget>[];
 
+    final timestamp = DateTime.fromMillisecondsSinceEpoch(_user!.networth!['timestamp']!.round() * 1000);
+    final formattedTimestamp = TimeFormatter(
+        inputTime: timestamp,
+        timeFormatSetting: _settingsProvider!.currentTimeFormat,
+        timeZoneSetting: _settingsProvider!.currentTimeZone).formatHourWithDaysElapsed();
+
     // Loop all other sources
     for (final v in _user!.networth!.entries) {
       String source;
-      if (v.key == 'total' || v.key == 'parsetime') {
+      if (v.key == 'total' || v.key == 'parsetime' || v.key == 'timestamp') {
         continue;
       } else if (v.key == 'piggybank') {
         source = 'Piggy Bank';
@@ -4838,6 +4844,13 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
               ),
               SizedBox(height: 10),
               ...moneySources,
+              SizedBox(height: 10),
+              Text(
+                'Updated at: ',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                )
+              )
             ],
           ),
           Column(
@@ -4852,6 +4865,14 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
               ),
               SizedBox(height: 10),
               ...moneyQuantities,
+              SizedBox(height: 10),
+              Text(
+                formattedTimestamp,
+                style: TextStyle(
+                  color: _themeProvider!.mainText,
+                  fontSize: 12,
+                ),
+              ),
             ],
           ),
         ],
@@ -4875,7 +4896,7 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
         collapsed: Padding(
           padding: const EdgeInsets.fromLTRB(25, 5, 20, 20),
           child: Text(
-            '\$${moneyFormat.format(total)}',
+            '\$${moneyFormat.format(total)} (updated $formattedTimestamp)',
             softWrap: true,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
# Goals
## GM Compatibility
- [ ] `@grant` headers for `GM_*`, `GM.*` and `PDA_*` API access, as well as `###PDA-APIKEY###` replacement. **Requires notice for developers - this is a breaking change**.
- [ ] `@require` header support
- [ ] Proper `@match` URL matching, rather than just a raw substring check
- [ ] Full `GM_*` and `GM.*` compatibility with ViolentMonkey where possible. ViolentMonkey is open-source, whereas modern TamperMonkey is not, therefore it will be much easier to achieve full compat here

## Script Installation
- [ ] Improved userscript detection for the install widget
- [ ] Better script update checks - once an hour?
- [ ] Options for how to handle new versions - notify / auto update / update icon / don't auto-check. 
- [ ] Some form of "hot reload" for development. **Must not auto-refresh the page on changes, as this is against the current scripting rules. Perhaps a toast, or just reload on each page load**.
- [ ] Warn user of `@grant` headers with a basic breakdown.

## Runtime
- [ ] Ability to connect to an external device for devtools
- [ ] Widget with currently running scripts and registered menu commands
- [ ] Better handling of serialisables in the console (fix `[object Object]` if possible)
- [ ] Show the source of logs in the console if possible, at least when originating from scripts themselves (override the native console object?)

## Documentation
- [ ] Requirements for the script install widget
- [ ] Steps for external devtools
- [ ] `PDA_*` API
- [ ] Hot reload

Currently a list of features that would be desirable. Some (`GM_*` compat) are more important than others (hot reload).