### PR TITLE
Improved error handling for TSC

### DIFF
--- a/lib/utils/external/tsc_comm.dart
+++ b/lib/utils/external/tsc_comm.dart
@@ -1,4 +1,5 @@
 // Package imports:
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
@@ -30,16 +31,50 @@ class TSCComm {
             headers: headers,
             body: body,
           )
-          .timeout(const Duration(seconds: 10));
+          .timeout(const Duration(seconds: 20));
 
       if (response.statusCode == 200) {
         tscModel = tscResponseFromJson(response.body);
       } else {
-        String message = "Connection Error ${response.statusCode}";
-
+        //     export enum ErrorCode {
+        //        InvalidRequest = 1,
+        //        Maintenance = 2,
+        //        InvalidApiKey = 3,
+        //        InternalError = 4,
+        //        UserDisabled = 5,
+        //        CachedOnly = 6,
+        //      }
         int errorCode = tscResponseFromJson(response.body).code ?? 0;
-        if (errorCode == 3) {
-          message = "Invalid API key";
+        String message;
+
+        switch (errorCode) {
+          case 1:
+            message = "Invalid request. Please contact a PDA developer.";
+            break;
+
+          case 2:
+            message = "TSC is undergoing maintenance. Please try again later.";
+            break;
+
+          case 3:
+            message = "Invalid API key.";
+            break;
+
+          case 4:
+            message = "An internal error has occurred. Please contact Mavri [2402357].";
+            break;
+
+          case 5:
+            message = "Your account has been disabled.";
+            break;
+
+          case 6:
+            message = "TSC is running in cache-only mode. This user couldn't be updated.";
+            break;
+
+          default:
+            message = "Unknown error occurred. Please try again later.\nStatus Code: ${response.statusCode}";
+            break;
         }
 
         tscModel = TscResponse(
@@ -50,7 +85,15 @@ class TSCComm {
         );
       }
     } catch (e, trace) {
-      tscModel = TscResponse(success: false, message: "Model error", spy: null);
+      String message;
+      if (e.runtimeType == TimeoutException) {
+        message = "Request timed out.";
+      } else {
+        message = "Model error";
+      }
+
+      tscModel = TscResponse(success: false, message: message, spy: null);
+
       if (response != null) {
         if (!Platform.isWindows) FirebaseCrashlytics.instance.log("TSC Crash: $e, trace: $trace");
         if (!Platform.isWindows) FirebaseCrashlytics.instance.recordError("HTTP Response: ${response.body}", null);

--- a/lib/utils/external/tsc_comm.dart
+++ b/lib/utils/external/tsc_comm.dart
@@ -86,7 +86,7 @@ class TSCComm {
       }
     } catch (e, trace) {
       String message;
-      if (e.runtimeType == TimeoutException) {
+      if (e is TimeoutException) {
         message = "Request timed out.";
       } else {
         message = "Model error";


### PR DESCRIPTION
* Every error code from TSC now has a description to go along with it.
* Separated the "model error" from timeouts.
* Increased timeout from 10s to 20s (seems to result in less errors when Torn's API is slow)