### PR TITLE
Add example script link to Hospital Filters

### DIFF
--- a/lib/models/userscript_model.dart
+++ b/lib/models/userscript_model.dart
@@ -364,7 +364,6 @@ class UserScriptModel {
     // 6: Company Activity
     "https://github.com/Manuito83/torn-pda/raw/master/userscripts/Company%20Activity%20(Torn%20PDA).js",
     // 7: Hospital Filters
-    // TODO: Add remote for Hosp Filters after merge
-    null,
+    "https://github.com/Manuito83/torn-pda/raw/master/userscripts/Hospital%20Revive%20Filters%20(Torn%20PDA).js",
   ];
 }


### PR DESCRIPTION
- Add a link to the Hospital Filters script

I noticed that I probably removed the Hospital Filters example script, or it hasn't been installed in the first place on my PDA.

In any case, the button for reinstalling example scripts didn't pull it in, and the fix seemed easy enough so here it is. :)

