### PR TITLE
Enhanced Android travel live notification with countdown and flags

### DIFF
--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdatePayload.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdatePayload.kt
@@ -20,6 +20,7 @@ data class LiveUpdatePayload(
     val showProgressBar: Boolean,
     val hasArrived: Boolean,
     val travelIdentifier: String?,
+    val destinationEmoji: String?,
     val extras: Map<String, Any?>,
 ) {
 
@@ -53,6 +54,7 @@ data class LiveUpdatePayload(
                 showProgressBar = safeMap["showProgressBar"] == true,
                 hasArrived = safeMap["hasArrived"] == true,
                 travelIdentifier = safeMap["travelIdentifier"] as? String,
+                destinationEmoji = safeMap["destinationEmoji"] as? String,
                 extras = safeMap,
             )
         }

--- a/android/app/src/main/res/drawable/ic_home_small.xml
+++ b/android/app/src/main/res/drawable/ic_home_small.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/android/app/src/main/res/drawable/travel_pill_argentina.xml
+++ b/android/app/src/main/res/drawable/travel_pill_argentina.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_argentina"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_canada.xml
+++ b/android/app/src/main/res/drawable/travel_pill_canada.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_canada"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_cayman.xml
+++ b/android/app/src/main/res/drawable/travel_pill_cayman.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_cayman"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_china.xml
+++ b/android/app/src/main/res/drawable/travel_pill_china.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_china"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_hawaii.xml
+++ b/android/app/src/main/res/drawable/travel_pill_hawaii.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_hawaii"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_japan.xml
+++ b/android/app/src/main/res/drawable/travel_pill_japan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_japan"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_mexico.xml
+++ b/android/app/src/main/res/drawable/travel_pill_mexico.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_mexico"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_south_africa.xml
+++ b/android/app/src/main/res/drawable/travel_pill_south_africa.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_south_africa"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_switzerland.xml
+++ b/android/app/src/main/res/drawable/travel_pill_switzerland.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_switzerland"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_torn.xml
+++ b/android/app/src/main/res/drawable/travel_pill_torn.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_left"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/ic_home_small"
+        android:width="10dp"
+        android:height="10dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_uae.xml
+++ b/android/app/src/main/res/drawable/travel_pill_uae.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_uae"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/drawable/travel_pill_uk.xml
+++ b/android/app/src/main/res/drawable/travel_pill_uk.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/plane_right"
+        android:gravity="center"/>
+    <item
+        android:drawable="@drawable/flag_uk"
+        android:width="12dp"
+        android:height="8dp"
+        android:gravity="end|bottom"/>
+</layer-list>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="live_update_eta_pattern">ETA %1$s</string>
     <string name="live_update_arrived_label">Arrived</string>
     <string name="live_update_unknown_eta">ETA unavailable</string>
+    <string name="live_update_arriving_pattern">Arriving in: %1$s at %2$s</string>
     <string name="live_update_destination_unknown">Unknown</string>
     <string name="live_update_notification_secondary">%1$s → %2$s</string>
 </resources>

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -926,12 +926,6 @@ class SettingsPageState extends State<SettingsPage> {
             ),
           ),
         ),
-      if (Platform.isAndroid)
-        SearchableRow(
-          label: "Mock travel live update",
-          searchText: _searchText,
-          child: _mockLiveUpdateRow(),
-        ),
       if (Platform.isIOS)
         SearchableRow(
           label: "Active Alarms",
@@ -3420,6 +3414,12 @@ class SettingsPageState extends State<SettingsPage> {
           ),
         ),
       ),
+      if (Platform.isAndroid)
+        SearchableRow(
+          label: "Mock travel live update",
+          searchText: _searchText,
+          child: _mockLiveUpdateRow(),
+        ),
     ];
 
     return buildSectionWithRows(

--- a/lib/utils/live_activities/live_activity_travel_controller.dart
+++ b/lib/utils/live_activities/live_activity_travel_controller.dart
@@ -316,6 +316,7 @@ class LiveActivityTravelController extends GetxController {
     String originFlagAsset;
     String vehicleAssetName;
     String activityStateTitle;
+    String destinationEmoji;
     int? earliestReturnTimestamp;
     bool showProgressBar = !hasArrived;
 
@@ -328,6 +329,7 @@ class LiveActivityTravelController extends GetxController {
       originFlagAsset = "hospital_origin_icon";
       vehicleAssetName = isChristmasTimeValue ? "sleigh" : "plane_left";
       activityStateTitle = hasArrived ? "Repatriated to" : "Repatriating to";
+      destinationEmoji = "\u{1F3E0}"; // Home emoji for Torn
     } else {
       final String destination = apiTravelData['destination']!;
       if (destination == "Torn") {
@@ -337,6 +339,7 @@ class LiveActivityTravelController extends GetxController {
         originFlagAsset = "world_origin_icon";
         vehicleAssetName = isChristmasTimeValue ? "sleigh" : "plane_left";
         activityStateTitle = hasArrived ? "Returned to" : "Returning to";
+        destinationEmoji = "\u{1F3E0}"; // Home emoji for Torn
       } else {
         currentDestinationDisplayName = destination;
         currentDestinationFlagAsset = "ball_${_normalizeCountryNameForAsset(destination)}";
@@ -344,6 +347,7 @@ class LiveActivityTravelController extends GetxController {
         originFlagAsset = "ball_torn";
         vehicleAssetName = isChristmasTimeValue ? "sleigh" : "plane_right";
         activityStateTitle = hasArrived ? "Arrived in" : "Traveling to";
+        destinationEmoji = _getCountryEmoji(destination);
 
         if (!hasArrived) {
           int travelDuration = apiTravelData['arrivalTimestamp']! - apiTravelData['departureTimestamp']!;
@@ -369,7 +373,27 @@ class LiveActivityTravelController extends GetxController {
       'activityStateTitle': activityStateTitle,
       'showProgressBar': showProgressBar,
       'hasArrived': hasArrived,
+      'destinationEmoji': destinationEmoji,
     };
+  }
+
+  String _getCountryEmoji(String countryName) {
+    // Unicode flag emojis use regional indicator symbols
+    // Each flag is composed of two regional indicator symbols
+    const Map<String, String> countryEmojis = {
+      'United Kingdom': '\u{1F1EC}\u{1F1E7}', // 🇬🇧
+      'Japan': '\u{1F1EF}\u{1F1F5}', // 🇯🇵
+      'Hawaii': '\u{1F1FA}\u{1F1F8}', // 🇺🇸 (US flag for Hawaii)
+      'China': '\u{1F1E8}\u{1F1F3}', // 🇨🇳
+      'Argentina': '\u{1F1E6}\u{1F1F7}', // 🇦🇷
+      'Canada': '\u{1F1E8}\u{1F1E6}', // 🇨🇦
+      'Cayman Islands': '\u{1F1F0}\u{1F1FE}', // 🇰🇾
+      'Mexico': '\u{1F1F2}\u{1F1FD}', // 🇲🇽
+      'South Africa': '\u{1F1FF}\u{1F1E6}', // 🇿🇦
+      'Switzerland': '\u{1F1E8}\u{1F1ED}', // 🇨🇭
+      'United Arab Emirates': '\u{1F1E6}\u{1F1EA}', // 🇦🇪
+    };
+    return countryEmojis[countryName] ?? '\u{1F30D}'; // Default to globe emoji
   }
 
   bool _isChristmas() {


### PR DESCRIPTION
Thanks for merging my first PR! Honestly - big fan, love TornPDA and it's insane for me that I'm able to make it a bit better in any way. Thank you for your work!

Anyway, this is the second take on Live Updates. This basically makes it a bit better. Also some housekeeping regarding testing/debugging.


## Notification Pill (Left Side)
- Added composite drawable icons combining plane + country flag overlay
- Created 12 destination-specific icons (travel_pill_*.xml) for all countries
- Added home icon (ic_home_small.xml) for Torn destination
- Plane direction: left for returning to Torn, right for traveling abroad

## Notification Pill (Right Side)
- Changed from arrival time "T 09:53" to countdown format
- Shows "23:45" (mm:ss) or "1:23:45" (h:mm:ss) depending on duration
- Displays "Arrived" when countdown reaches zero

## Expanded Notification Content
- Title now includes country flag emoji: "Traveling to UK 🇬🇧"
- Home emoji for Torn: "Returning to Torn 🏠"
- Content changed from "ETA 09:53" to "Arriving in: 1:23:45 at 09:53"

## Arrival State Fix
- Fixed negative countdown bug (-3 minutes issue)
- Now checks actual time (arrivalMillis <= nowMillis) not just Flutter's hasArrived flag
- Properly disables chronometer when arrival time has passed
- Updates setOngoing/setAutoCancel based on real arrival status

## Performance
- Reduced update interval from 60s to 15s for smoother countdown

## Settings Cleanup
- Moved "Mock travel live update" from NOTIFICATIONS to TROUBLESHOOTING section
- Debug/testing options now grouped with other diagnostic tools

## Files Changed
- AndroidLiveUpdateAdapter.kt: Core notification rendering logic
- LiveUpdatePayload.kt: Added destinationEmoji field
- live_activity_travel_controller.dart: Added emoji mapping for countries
- strings.xml: Added live_update_arriving_pattern
- settings_page.dart: Relocated mock option to troubleshooting

## New Drawable Resources (13 files)
- ic_home_small.xml (home icon vector)
- travel_pill_torn.xml, travel_pill_uk.xml, travel_pill_japan.xml
- travel_pill_hawaii.xml, travel_pill_china.xml, travel_pill_argentina.xml
- travel_pill_canada.xml, travel_pill_cayman.xml, travel_pill_mexico.xml
- travel_pill_south_africa.xml, travel_pill_switzerland.xml, travel_pill_uae.xml