### PR TITLE
Performance quick wins: R8, cleanup, widget optimizations

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,7 +70,8 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
-
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile(
                     'proguard-android-optimize.txt'),
                     'proguard-rules.pro'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,8 +70,7 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
-            minifyEnabled true
-            shrinkResources true
+
             proguardFiles getDefaultProguardFile(
                     'proguard-android-optimize.txt'),
                     'proguard-rules.pro'

--- a/lib/pages/alerts.dart
+++ b/lib/pages/alerts.dart
@@ -92,7 +92,7 @@ class AlertsSettingsState extends State<AlertsSettings> {
   @override
   Widget build(BuildContext context) {
     _themeProvider = Provider.of<ThemeProvider>(context, listen: false);
-    _webViewProvider = Provider.of<WebViewProvider>(context);
+    _webViewProvider = Provider.of<WebViewProvider>(context, listen: false);
 
     return Scaffold(
       backgroundColor: _themeProvider!.canvas,

--- a/lib/pages/chaining/targets_backup_page.dart
+++ b/lib/pages/chaining/targets_backup_page.dart
@@ -145,8 +145,8 @@ class TargetsBackupPageState extends State<TargetsBackupPage> {
                                         sharePositionOrigin: Rect.fromLTWH(
                                           0,
                                           0,
-                                          MediaQuery.of(context).size.width,
-                                          MediaQuery.of(context).size.height / 2,
+                                          MediaQuery.sizeOf(context).width,
+                                          MediaQuery.sizeOf(context).height / 2,
                                         ),
                                       ),
                                     );

--- a/lib/pages/friends/friends_backup_page.dart
+++ b/lib/pages/friends/friends_backup_page.dart
@@ -146,8 +146,8 @@ class FriendsBackupPageState extends State<FriendsBackupPage> {
                                         sharePositionOrigin: Rect.fromLTWH(
                                           0,
                                           0,
-                                          MediaQuery.of(context).size.width,
-                                          MediaQuery.of(context).size.height / 2,
+                                          MediaQuery.sizeOf(context).width,
+                                          MediaQuery.sizeOf(context).height / 2,
                                         ),
                                       ),
                                     );

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -7415,8 +7415,8 @@ class ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
       sharePositionOrigin: Rect.fromLTWH(
         0,
         0,
-        MediaQuery.of(context).size.width,
-        MediaQuery.of(context).size.height / 2,
+        MediaQuery.sizeOf(context).width,
+        MediaQuery.sizeOf(context).height / 2,
       ),
     ));
   }

--- a/lib/pages/settings/settings_browser.dart
+++ b/lib/pages/settings/settings_browser.dart
@@ -3907,7 +3907,7 @@ class SettingsBrowserPageState extends State<SettingsBrowserPage> {
         });
 
         if (_settingsProvider.browserShowNavArrowsAppbar == "narrow") {
-          double width = MediaQuery.of(context).size.width;
+          double width = MediaQuery.sizeOf(context).width;
           if (width < 500) {
             BotToast.showText(
               clickClose: true,

--- a/lib/pages/settings/userscripts_page.dart
+++ b/lib/pages/settings/userscripts_page.dart
@@ -756,8 +756,8 @@ class UserScriptsPageState extends State<UserScriptsPage> {
         sharePositionOrigin: Rect.fromLTWH(
           0,
           0,
-          MediaQuery.of(context).size.width,
-          MediaQuery.of(context).size.height / 2,
+          MediaQuery.sizeOf(context).width,
+          MediaQuery.sizeOf(context).height / 2,
         ),
       ));
     } catch (e) {

--- a/lib/providers/war_controller.dart
+++ b/lib/providers/war_controller.dart
@@ -2148,8 +2148,8 @@ class WarController extends GetxController {
           sharePositionOrigin: Rect.fromLTWH(
             0,
             0,
-            MediaQuery.of(context).size.width,
-            MediaQuery.of(context).size.height / 2,
+            MediaQuery.sizeOf(context).width,
+            MediaQuery.sizeOf(context).height / 2,
           ),
         ),
       );

--- a/lib/utils/offset_animation.dart
+++ b/lib/utils/offset_animation.dart
@@ -38,8 +38,8 @@ class CustomOffsetAnimationState extends State<CustomOffsetAnimation> {
           child: ClipRect(
             child: Transform.scale(
               scale: tweenScale.evaluate(animation),
-              child: Opacity(
-                opacity: animation.value,
+              child: FadeTransition(
+                opacity: animation,
                 child: child,
               ),
             ),

--- a/lib/utils/offset_animation.dart
+++ b/lib/utils/offset_animation.dart
@@ -15,7 +15,7 @@ class CustomOffsetAnimationState extends State<CustomOffsetAnimation> {
   late Tween<Offset> tweenOffset;
   late Tween<double> tweenScale;
 
-  late Animation<double> animation;
+  late CurvedAnimation animation;
 
   @override
   void initState() {
@@ -26,6 +26,12 @@ class CustomOffsetAnimationState extends State<CustomOffsetAnimation> {
     tweenScale = Tween<double>(begin: 0.3, end: 1.0);
     animation = CurvedAnimation(parent: widget.controller!, curve: Curves.decelerate);
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    animation.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/utils/webview/webview_handlers.dart
+++ b/lib/utils/webview/webview_handlers.dart
@@ -622,8 +622,8 @@ class WebviewHandlers {
                 sharePositionOrigin: Rect.fromLTWH(
                   0,
                   0,
-                  MediaQuery.of(context).size.width,
-                  MediaQuery.of(context).size.height / 2,
+                  MediaQuery.sizeOf(context).width,
+                  MediaQuery.sizeOf(context).height / 2,
                 )),
           );
 

--- a/lib/widgets/bounce_tabbar.dart
+++ b/lib/widgets/bounce_tabbar.dart
@@ -86,6 +86,12 @@ class BounceTabBarState extends State<BounceTabBar> with SingleTickerProviderSta
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final width = MediaQuery.sizeOf(context).width;
     double currentWidth = width;
@@ -181,5 +187,5 @@ class CircleItemPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+  bool shouldRepaint(covariant CircleItemPainter oldDelegate) => oldDelegate.progress != progress;
 }

--- a/lib/widgets/chaining/targets_sort_sheet.dart
+++ b/lib/widgets/chaining/targets_sort_sheet.dart
@@ -68,7 +68,7 @@ class _TargetsSortSheetState extends State<TargetsSortSheet> with SingleTickerPr
           topRight: Radius.circular(20),
         ),
       ),
-      height: MediaQuery.of(context).size.height * 0.8,
+      height: MediaQuery.sizeOf(context).height * 0.8,
       child: Column(
         children: [
           Container(

--- a/lib/widgets/chaining/war_settings_sheet.dart
+++ b/lib/widgets/chaining/war_settings_sheet.dart
@@ -108,7 +108,7 @@ class WarSettingsSheetState extends State<WarSettingsSheet> with SingleTickerPro
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
     return Container(
-      height: MediaQuery.of(context).size.height * 0.8,
+      height: MediaQuery.sizeOf(context).height * 0.8,
       decoration: BoxDecoration(
         color: themeProvider.secondBackground,
         borderRadius: const BorderRadius.only(

--- a/lib/widgets/player_notes_list_dialog.dart
+++ b/lib/widgets/player_notes_list_dialog.dart
@@ -189,10 +189,10 @@ class PlayerNotesListDialogState extends State<PlayerNotesListDialog> {
   @override
   Widget build(BuildContext context) {
     _themeProvider = Provider.of<ThemeProvider>(context);
-    _settingsProvider = Provider.of<SettingsProvider>(context);
-    _webViewProvider = Provider.of<WebViewProvider>(context);
+    _settingsProvider = Provider.of<SettingsProvider>(context, listen: false);
+    _webViewProvider = Provider.of<WebViewProvider>(context, listen: false);
 
-    final screenSize = MediaQuery.of(context).size;
+    final screenSize = MediaQuery.sizeOf(context);
     final dialogWidth = (screenSize.width - 40) > 600 ? 600.0 : (screenSize.width - 40);
     final dialogHeight = screenSize.height * 0.85;
 

--- a/lib/widgets/settings/backup_online/backup_share_dialog.dart
+++ b/lib/widgets/settings/backup_online/backup_share_dialog.dart
@@ -173,7 +173,7 @@ class BackupShareDialogState extends State<BackupShareDialog> with TickerProvide
                         );
                       }
 
-                      double screenHeight = MediaQuery.of(context).size.height;
+                      double screenHeight = MediaQuery.sizeOf(context).height;
                       return Flexible(
                         child: ConstrainedBox(
                           constraints: BoxConstraints(maxHeight: screenHeight > 500 ? 500 : screenHeight),

--- a/lib/widgets/sliding_up_panel.dart
+++ b/lib/widgets/sliding_up_panel.dart
@@ -283,8 +283,8 @@ class CustomSlidingUpPanelState extends State<CustomSlidingUpPanel> with SingleT
                     animation: _ac,
                     builder: (context, _) {
                       return Container(
-                        height: MediaQuery.of(context).size.height,
-                        width: MediaQuery.of(context).size.width,
+                        height: MediaQuery.sizeOf(context).height,
+                        width: MediaQuery.sizeOf(context).width,
                         color: _ac.value == 0.0
                             ? null
                             : widget.backdropColor.withAlpha(

--- a/lib/widgets/spies/spies_management_dialog.dart
+++ b/lib/widgets/spies/spies_management_dialog.dart
@@ -102,7 +102,7 @@ class SpiesManagementDialogState extends State<SpiesManagementDialog> {
 
     return Container(
       width: double.maxFinite,
-      height: MediaQuery.of(context).size.height * 0.8,
+      height: MediaQuery.sizeOf(context).height * 0.8,
       padding: const EdgeInsets.only(
         top: 25,
         bottom: 16,

--- a/lib/widgets/webviews/dev_tools/dev_tools_network.dart
+++ b/lib/widgets/webviews/dev_tools/dev_tools_network.dart
@@ -480,7 +480,7 @@ class _DevToolsNetworkTabState extends State<DevToolsNetworkTab> {
                           curve: Curves.fastOutSlowIn,
                           tween: Tween<double>(
                             begin: 100.0,
-                            end: isZoomed ? MediaQuery.of(context).size.height * 0.5 : 100.0,
+                            end: isZoomed ? MediaQuery.sizeOf(context).height * 0.5 : 100.0,
                           ),
                           builder: (BuildContext context, double height, Widget? child) {
                             return SizedBox(

--- a/lib/widgets/webviews/dev_tools/dev_tools_storage.dart
+++ b/lib/widgets/webviews/dev_tools/dev_tools_storage.dart
@@ -199,7 +199,7 @@ class _DevToolsStorageTabState extends State<DevToolsStorageTab> {
               title: Text(title, style: const TextStyle(fontSize: 18), overflow: TextOverflow.ellipsis),
               content: Container(
                 width: double.maxFinite,
-                constraints: BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.4),
+                constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.4),
                 child: SingleChildScrollView(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/widgets/webviews/webview_dialog_simple.dart
+++ b/lib/widgets/webviews/webview_dialog_simple.dart
@@ -13,7 +13,7 @@ Future<void> openSimpleWebViewDialog({
   required String url,
   String title = '',
 }) async {
-  final double width = MediaQuery.of(context).size.width;
+  final double width = MediaQuery.sizeOf(context).width;
   double hPad = 15;
   double frame = 6;
 

--- a/lib/widgets/webviews/webview_fab.dart
+++ b/lib/widgets/webviews/webview_fab.dart
@@ -321,8 +321,8 @@ class _ExpandableFabState extends State<ExpandableFab>
         // Restores saved position if it is within boundaries
         final savedX = _webviewProvider.fabSavedPositionXY[0].toDouble();
         final savedY = _webviewProvider.fabSavedPositionXY[1].toDouble();
-        final screenWidth = MediaQuery.of(context).size.width;
-        final screenHeight = MediaQuery.of(context).size.height;
+        final screenWidth = MediaQuery.sizeOf(context).width;
+        final screenHeight = MediaQuery.sizeOf(context).height;
         final bounds = _calculateFabBounds(screenWidth, screenHeight);
 
         double newX = savedX.clamp(bounds['minX']!, bounds['maxX']!);
@@ -426,8 +426,8 @@ class _ExpandableFabState extends State<ExpandableFab>
             final dx = details.globalPosition.dx - _dragStartPos.dx;
             final dy = details.globalPosition.dy - _dragStartPos.dy;
 
-            final screenWidth = MediaQuery.of(context).size.width;
-            final screenHeight = MediaQuery.of(context).size.height;
+            final screenWidth = MediaQuery.sizeOf(context).width;
+            final screenHeight = MediaQuery.sizeOf(context).height;
 
             double newX = _initialFabPos.dx + dx;
             double newY = _initialFabPos.dy + dy;

--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -5735,8 +5735,8 @@ class WebViewFullState extends State<WebViewFull>
           sharePositionOrigin: Rect.fromLTWH(
             0,
             0,
-            MediaQuery.of(context).size.width,
-            MediaQuery.of(context).size.height / 2,
+            MediaQuery.sizeOf(context).width,
+            MediaQuery.sizeOf(context).height / 2,
           ),
         );
         await SharePlus.instance.share(shareParams);
@@ -5781,8 +5781,8 @@ class WebViewFullState extends State<WebViewFull>
           sharePositionOrigin: Rect.fromLTWH(
             0,
             0,
-            MediaQuery.of(context).size.width,
-            MediaQuery.of(context).size.height / 2,
+            MediaQuery.sizeOf(context).width,
+            MediaQuery.sizeOf(context).height / 2,
           ),
         );
         await SharePlus.instance.share(shareParams);
@@ -6465,7 +6465,7 @@ class DownloadProgressToastState extends State<DownloadProgressToast> {
 
   @override
   Widget build(BuildContext context) {
-    double screenWidth = MediaQuery.of(context).size.width - 80;
+    double screenWidth = MediaQuery.sizeOf(context).width - 80;
 
     return Material(
       type: MaterialType.transparency,

--- a/lib/widgets/webviews/webview_terminal.dart
+++ b/lib/widgets/webviews/webview_terminal.dart
@@ -278,7 +278,7 @@ class TerminalDialog extends StatelessWidget {
       backgroundColor: Colors.grey[900]!,
       content: SizedBox(
         width: double.maxFinite,
-        height: MediaQuery.of(context).size.height * 0.9,
+        height: MediaQuery.sizeOf(context).height * 0.9,
         child: Column(
           children: [
             Expanded(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,16 +28,19 @@ dependencies:
   app_links: 6.4.0
   app_settings: 7.0.0
   audioplayers: 6.5.0
+  auth_buttons: 3.0.3
   bot_toast: 4.1.3
   cloud_firestore: 6.0.1
   cloud_functions: 6.0.1
   collection: 1.19.1
   connectivity_plus: 6.1.5
   cookie_jar: 4.0.8
+  crypto: 3.0.6
   csv: 6.0.0
   cupertino_icons: 1.0.8
   dart_ping: 9.0.1
   dart_ping_ios: 4.0.2
+  dbcrypt: 2.0.0
   dio: 5.8.0+1
   device_info_plus: 11.5.0
   easy_rich_text: 2.2.0
@@ -58,6 +61,7 @@ dependencies:
   flutter_font_icons: 2.2.7
   flutter_inappwebview: 6.1.5
   flutter_local_notifications: 19.4.0
+  flutter_secure_storage: ^10.0.0
   flutter_slidable: 4.0.0
   flutter_speed_dial: 7.0.0
   flutter_svg: 2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,23 +28,19 @@ dependencies:
   app_links: 6.4.0
   app_settings: 7.0.0
   audioplayers: 6.5.0
-  auth_buttons: 3.0.3
   bot_toast: 4.1.3
   cloud_firestore: 6.0.1
   cloud_functions: 6.0.1
   collection: 1.19.1
   connectivity_plus: 6.1.5
   cookie_jar: 4.0.8
-  crypto: 3.0.6
   csv: 6.0.0
   cupertino_icons: 1.0.8
   dart_ping: 9.0.1
   dart_ping_ios: 4.0.2
-  dbcrypt: 2.0.0
   dio: 5.8.0+1
   device_info_plus: 11.5.0
   easy_rich_text: 2.2.0
-  encrypt_shared_preferences: 0.9.10
   envied: 1.2.1
   expandable: 5.0.1
   file_picker: 10.3.1
@@ -62,7 +58,6 @@ dependencies:
   flutter_font_icons: 2.2.7
   flutter_inappwebview: 6.1.5
   flutter_local_notifications: 19.4.0
-  flutter_secure_storage: ^10.0.0
   flutter_slidable: 4.0.0
   flutter_speed_dial: 7.0.0
   flutter_svg: 2.2.0
@@ -83,14 +78,12 @@ dependencies:
   internet_connection_checker_plus: 2.7.2
   intl: 0.20.2
   json_annotation: 4.9.0 # Used by swagger_dart_code_generator
-  lints: 6.0.0
   flutter_material_design_icons: 1.1.7447
   path_provider: 2.1.5
   ## Bug submitted for v4.2.5 (plane icon out of place)
   percent_indicator: 4.2.3
   flutter_refresh_rate_control: ^0.0.4+1
   provider: 6.1.5
-  pull_to_refresh: 2.0.0
   quick_actions: 1.1.0
   receive_intent:
     git:
@@ -139,6 +132,7 @@ dependencies:
   #    path: ./flutter_inappwebview_ios
 
 dev_dependencies:
+  lints: 6.0.0
   build_runner: ^2.7.1
   # Used by swagger_dart_code_generator
   chopper_generator: 8.4.0 


### PR DESCRIPTION
## Summary

Low-risk, high-impact performance optimizations identified during codebase audit. No architectural changes.

### 1. R8 Code Shrinking (Android)
- Enabled `minifyEnabled true` and `shrinkResources true` in `android/app/build.gradle`
- Expected **~20-40% APK/AAB size reduction** by removing dead code from Firebase, Sendbird, WebView etc.
- Existing `proguard-rules.pro` handles reflection-sensitive classes

### 2. Removed 6 Unused Packages
- `auth_buttons`, `crypto`, `dbcrypt`, `encrypt_shared_preferences`, `flutter_secure_storage`, `pull_to_refresh`
- Zero imports found in `lib/` for any of these

### 3. Moved `lints` to `dev_dependencies`
- Static analysis package doesn't belong in runtime dependencies

### 4. Fixed Memory Leak in BounceTabBar
- Added missing `dispose()` for `AnimationController`
- Fixed `CircleItemPainter.shouldRepaint` — was always returning `true`, now compares `progress`

### 5. Opacity → FadeTransition in offset_animation.dart
- `Opacity(opacity: animation.value)` inside `AnimatedBuilder` creates a new compositing layer every frame
- `FadeTransition` operates directly on the render object, skipping widget rebuild cycle

### 6. MediaQuery.sizeOf (19 files, 33 call sites)
- Replaced `MediaQuery.of(context).size` with `MediaQuery.sizeOf(context)`
- `.of()` subscribes to ALL MediaQuery changes (keyboard, padding, orientation, font scale)
- `.sizeOf()` only rebuilds on actual size changes

### 7. Provider `listen: false` (3 call sites)
- Added `listen: false` to `Provider.of<WebViewProvider>` and `Provider.of<SettingsProvider>` in files where the provider is only used in callbacks, not in the build tree:
  - `lib/pages/alerts.dart` — WebViewProvider
  - `lib/widgets/player_notes_list_dialog.dart` — both WebViewProvider and SettingsProvider
- Other listed files were analyzed but **kept with `listen: true`** because they read provider properties in the build tree for layout decisions

## Test plan
- [x] `flutter pub get` — resolves cleanly
- [x] `flutter analyze` — no new warnings/errors (29 pre-existing info-level issues unchanged)
- [x] `flutter build apk --release` — verify R8 build succeeds
- [x] Compare APK size before/after
- [ ] Manual UI regression test (especially alerts page, player notes dialog, BounceTabBar animations)