### PR TITLE
Fix/android live updates session 3

### DIFF
--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/AndroidLiveUpdateAdapter.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/AndroidLiveUpdateAdapter.kt
@@ -38,6 +38,17 @@ class AndroidTravelLiveUpdateAdapter(
             cachedPayload?.travelIdentifier != payload.travelIdentifier ||
             cachedPayload?.hasArrived != payload.hasArrived
 
+        // Defense-in-depth: skip redundant notification update for identical state
+        if (isExistingSession) {
+            val cached = cachedPayload!!
+            if (cached.travelIdentifier == payload.travelIdentifier
+                && cached.hasArrived == payload.hasArrived
+            ) {
+                cachedPayload = payload
+                return LiveUpdateAdapterResult(status = LiveUpdateRequestStatus.UPDATED)
+            }
+        }
+
         activeSessionId = sessionId
         cachedPayload = payload
 

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/AndroidLiveUpdateAdapter.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/AndroidLiveUpdateAdapter.kt
@@ -38,17 +38,6 @@ class AndroidTravelLiveUpdateAdapter(
             cachedPayload?.travelIdentifier != payload.travelIdentifier ||
             cachedPayload?.hasArrived != payload.hasArrived
 
-        // Defense-in-depth: skip redundant notification update for identical state
-        if (isExistingSession) {
-            val cached = cachedPayload!!
-            if (cached.travelIdentifier == payload.travelIdentifier
-                && cached.hasArrived == payload.hasArrived
-            ) {
-                cachedPayload = payload
-                return LiveUpdateAdapterResult(status = LiveUpdateRequestStatus.UPDATED)
-            }
-        }
-
         activeSessionId = sessionId
         cachedPayload = payload
 

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
@@ -45,8 +45,7 @@ class DefaultLiveUpdateManager(
         val existingSession = sessionStore.current()
         val sessionId = existingSession?.sessionId ?: sessionIdProvider()
 
-        // Skip adapter when nothing observable changed — avoids re-popping the heads-up
-        // notification and re-arming WorkManager alarms on every poll.
+        // Dedup avoids re-popping the heads-up and re-arming WorkManager on every poll.
         if (existingSession != null
             && existingSession.contentIdentifier == parsedPayload.contentIdentifier
             && existingSession.lastHasArrived == parsedPayload.hasArrived

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
@@ -44,6 +44,20 @@ class DefaultLiveUpdateManager(
         val now = System.currentTimeMillis()
         val existingSession = sessionStore.current()
         val sessionId = existingSession?.sessionId ?: sessionIdProvider()
+
+        // Dedup: skip adapter if same content, same arrived state
+        if (existingSession != null
+            && existingSession.contentIdentifier == parsedPayload.contentIdentifier
+            && existingSession.lastHasArrived == parsedPayload.hasArrived
+        ) {
+            sessionStore.markActive(existingSession.copy(lastUpdatedAtMs = now))
+            return@synchronized LiveUpdateStartResult(
+                status = LiveUpdateRequestStatus.UPDATED,
+                sessionId = sessionId,
+                capabilitySnapshot = eligibility.snapshot,
+            )
+        }
+
         sessionStore.markActive(
             LiveUpdateSessionState(
                 sessionId = sessionId,
@@ -51,6 +65,7 @@ class DefaultLiveUpdateManager(
                 contentIdentifier = parsedPayload.contentIdentifier,
                 startedAtMs = existingSession?.startedAtMs ?: now,
                 lastUpdatedAtMs = now,
+                lastHasArrived = parsedPayload.hasArrived,
             ),
         )
 

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
@@ -45,12 +45,12 @@ class DefaultLiveUpdateManager(
         val existingSession = sessionStore.current()
         val sessionId = existingSession?.sessionId ?: sessionIdProvider()
 
-        // Dedup: skip adapter if same content, same arrived state
+        // Skip adapter when nothing observable changed — avoids re-popping the heads-up
+        // notification and re-arming WorkManager alarms on every poll.
         if (existingSession != null
             && existingSession.contentIdentifier == parsedPayload.contentIdentifier
             && existingSession.lastHasArrived == parsedPayload.hasArrived
         ) {
-            sessionStore.markActive(existingSession.copy(lastUpdatedAtMs = now))
             return@synchronized LiveUpdateStartResult(
                 status = LiveUpdateRequestStatus.UPDATED,
                 sessionId = sessionId,

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManager.kt
@@ -31,9 +31,9 @@ class DefaultLiveUpdateManager(
         }
 
         val eligibility = eligibilityProvider.evaluate()
-        notifyCapability(eligibility.snapshot)
 
         if (!eligibility.eligible) {
+            notifyCapability(eligibility.snapshot)
             return@synchronized LiveUpdateStartResult(
                 status = LiveUpdateRequestStatus.UNSUPPORTED,
                 reason = eligibility.reason,
@@ -57,6 +57,8 @@ class DefaultLiveUpdateManager(
                 capabilitySnapshot = eligibility.snapshot,
             )
         }
+
+        notifyCapability(eligibility.snapshot)
 
         sessionStore.markActive(
             LiveUpdateSessionState(

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateCapabilityStore.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateCapabilityStore.kt
@@ -22,6 +22,7 @@ class LiveUpdateCapabilityStore(context: Context) : LiveUpdateCapabilityCache {
             putBoolean(KEY_SUPPORTED_API, snapshot.supportedApi)
             putBoolean(KEY_OEM_CAPSULE, snapshot.oemCapsule)
             putBoolean(KEY_NOTIFICATIONS_ENABLED, snapshot.notificationsEnabled)
+            putBoolean(KEY_PROMOTED_NOTIFICATIONS_ENABLED, snapshot.promotedNotificationsEnabled)
             putBoolean(KEY_BATTERY_OPTIMIZED, snapshot.batteryOptimized)
             putString(KEY_VENDOR, snapshot.vendor)
             snapshot.timestampMs?.let { putLong(KEY_TIMESTAMP, it) } ?: remove(KEY_TIMESTAMP)
@@ -34,6 +35,7 @@ class LiveUpdateCapabilityStore(context: Context) : LiveUpdateCapabilityCache {
             supportedApi = prefs.getBoolean(KEY_SUPPORTED_API, false),
             oemCapsule = prefs.getBoolean(KEY_OEM_CAPSULE, false),
             notificationsEnabled = prefs.getBoolean(KEY_NOTIFICATIONS_ENABLED, false),
+            promotedNotificationsEnabled = prefs.getBoolean(KEY_PROMOTED_NOTIFICATIONS_ENABLED, true),
             batteryOptimized = prefs.getBoolean(KEY_BATTERY_OPTIMIZED, true),
             vendor = prefs.getString(KEY_VENDOR, "unknown").orEmpty(),
             timestampMs = if (prefs.contains(KEY_TIMESTAMP)) prefs.getLong(KEY_TIMESTAMP, 0L) else null,
@@ -45,6 +47,7 @@ class LiveUpdateCapabilityStore(context: Context) : LiveUpdateCapabilityCache {
         private const val KEY_SUPPORTED_API = "supported_api"
         private const val KEY_OEM_CAPSULE = "oem_capsule"
         private const val KEY_NOTIFICATIONS_ENABLED = "notifications_enabled"
+        private const val KEY_PROMOTED_NOTIFICATIONS_ENABLED = "promoted_notifications_enabled"
         private const val KEY_BATTERY_OPTIMIZED = "battery_optimized"
         private const val KEY_VENDOR = "vendor"
         private const val KEY_TIMESTAMP = "timestamp"

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateChannelBridge.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateChannelBridge.kt
@@ -1,5 +1,10 @@
 package com.manuito.tornpda.liveupdates
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
@@ -7,6 +12,7 @@ class LiveUpdateChannelBridge(
     private val travelManager: LiveUpdateManager,
     private val racingManager: LiveUpdateManager,
     private val eventEmitter: LiveUpdateEventEmitter,
+    private val context: Context? = null,
 ) : MethodChannel.MethodCallHandler, LiveUpdateManagerListener {
 
     init {
@@ -59,6 +65,10 @@ class LiveUpdateChannelBridge(
                     result.success(null)
                 }
 
+                OPEN_PROMOTED_NOTIFICATIONS_SETTINGS -> {
+                    result.success(openPromotedNotificationsSettings())
+                }
+
                 else -> result.notImplemented()
             }
         } catch (exception: Exception) {
@@ -79,6 +89,24 @@ class LiveUpdateChannelBridge(
         racingManager.removeListener(this)
     }
 
+    private fun openPromotedNotificationsSettings(): Boolean {
+        val ctx = context ?: return false
+        val action = if (Build.VERSION.SDK_INT >= 36) {
+            "android.settings.MANAGE_APP_PROMOTED_NOTIFICATIONS"
+        } else {
+            Settings.ACTION_APP_NOTIFICATION_SETTINGS
+        }
+        val intent = Intent(action)
+            .putExtra(Settings.EXTRA_APP_PACKAGE, ctx.packageName)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return try {
+            ctx.startActivity(intent)
+            true
+        } catch (_: ActivityNotFoundException) {
+            false
+        }
+    }
+
     companion object {
         const val CHANNEL_NAME = "com.tornpda.liveactivity"
         private const val START_TRAVEL_ACTIVITY = "startTravelActivity"
@@ -89,5 +117,6 @@ class LiveUpdateChannelBridge(
         private const val IS_ANY_RACING_ACTIVITY_ACTIVE = "isAnyRacingActivityActive"
         private const val GET_PUSH_TO_START_TOKEN = "getPushToStartToken"
         private const val GET_LIVE_UPDATE_CAPABILITIES = "getLiveUpdateCapabilities"
+        private const val OPEN_PROMOTED_NOTIFICATIONS_SETTINGS = "openPromotedNotificationsSettings"
     }
 }

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateContracts.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateContracts.kt
@@ -28,6 +28,7 @@ enum class LiveUpdateUnsupportedReason(val wireName: String) {
     API_TOO_OLD("API_TOO_OLD"),
     OEM_UNAVAILABLE("OEM_UNAVAILABLE"),
     PERMISSION_DENIED("PERMISSION_DENIED"),
+    PROMOTED_DISABLED("PROMOTED_DISABLED"),
     BATTERY_RESTRICTED("BATTERY_RESTRICTED"),
     INTERNAL_ERROR("INTERNAL_ERROR"),
     UNKNOWN("UNKNOWN");
@@ -54,6 +55,7 @@ data class LiveUpdateCapabilitySnapshot(
     val supportedApi: Boolean,
     val oemCapsule: Boolean,
     val notificationsEnabled: Boolean,
+    val promotedNotificationsEnabled: Boolean = true,
     val batteryOptimized: Boolean,
     val vendor: String,
     val timestampMs: Long? = null,
@@ -62,6 +64,7 @@ data class LiveUpdateCapabilitySnapshot(
         "supportedApi" to supportedApi,
         "oemCapsule" to oemCapsule,
         "notificationsEnabled" to notificationsEnabled,
+        "promotedNotificationsEnabled" to promotedNotificationsEnabled,
         "batteryOptimized" to batteryOptimized,
         "vendor" to vendor,
         "timestamp" to timestampMs,

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateEligibilityEvaluator.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateEligibilityEvaluator.kt
@@ -1,6 +1,7 @@
 package com.manuito.tornpda.liveupdates
 
 import android.Manifest
+import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -26,6 +27,7 @@ class LiveUpdateEligibilityEvaluator(
     private val requiredApiLevel: Int = DEFAULT_REQUIRED_API_LEVEL,
     private val apiLevelProvider: () -> Int = { Build.VERSION.SDK_INT },
     private val notificationsAllowedProvider: (() -> Boolean)? = null,
+    private val promotedNotificationsAllowedProvider: (() -> Boolean)? = null,
     private val batteryOptimizedProvider: (() -> Boolean)? = null,
     private val vendorProvider: () -> String = { Build.MANUFACTURER ?: "unknown" },
 ) : LiveUpdateEligibilityProvider {
@@ -46,12 +48,14 @@ class LiveUpdateEligibilityEvaluator(
     private fun buildSnapshot(): LiveUpdateCapabilitySnapshot {
         val supportedApi = apiLevelProvider() >= requiredApiLevel
         val notificationsEnabled = notificationsAllowedProvider?.invoke() ?: notificationsAllowed()
+        val promotedAllowed = promotedNotificationsAllowedProvider?.invoke() ?: promotedNotificationsAllowed()
         val batteryOptimized = batteryOptimizedProvider?.invoke() ?: isBatteryOptimized()
         val vendor = vendorProvider().ifEmpty { "unknown" }.lowercase()
         return LiveUpdateCapabilitySnapshot(
             supportedApi = supportedApi,
             oemCapsule = false,
             notificationsEnabled = notificationsEnabled,
+            promotedNotificationsEnabled = promotedAllowed,
             batteryOptimized = batteryOptimized,
             vendor = vendor,
             timestampMs = timeProvider(),
@@ -62,6 +66,7 @@ class LiveUpdateEligibilityEvaluator(
         return when {
             !snapshot.supportedApi -> LiveUpdateUnsupportedReason.API_TOO_OLD
             !snapshot.notificationsEnabled -> LiveUpdateUnsupportedReason.PERMISSION_DENIED
+            !snapshot.promotedNotificationsEnabled -> LiveUpdateUnsupportedReason.PROMOTED_DISABLED
             snapshot.batteryOptimized -> LiveUpdateUnsupportedReason.BATTERY_RESTRICTED
             else -> null
         }
@@ -78,6 +83,17 @@ class LiveUpdateEligibilityEvaluator(
             if (!granted) return false
         }
         return true
+    }
+
+    private fun promotedNotificationsAllowed(): Boolean {
+        if (Build.VERSION.SDK_INT < 36) return true
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager ?: return true
+        return try {
+            val method = manager.javaClass.getMethod("canPostPromotedNotifications")
+            method.invoke(manager) as? Boolean ?: true
+        } catch (_: Throwable) {
+            true
+        }
     }
 
     private fun isBatteryOptimized(): Boolean {

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationChannel.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationChannel.kt
@@ -17,7 +17,7 @@ object LiveUpdateNotificationChannel {
         val manager = context.getSystemService<NotificationManager>() ?: return
         val channelId = channelIdFor(activityType)
 
-        // Migrate existing HIGH-importance channel down to DEFAULT to stop heads-up re-popping
+        // Migrate HIGH-importance channels down to DEFAULT; HIGH re-popped heads-up on every refresh.
         val existing = manager.getNotificationChannel(channelId)
         if (existing != null) {
             if (existing.importance == NotificationManager.IMPORTANCE_HIGH) {
@@ -36,7 +36,6 @@ object LiveUpdateNotificationChannel {
             enableVibration(false)
             setShowBadge(false)
             lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-            // Configure channel to be silent
             setSound(null, null)
         }
         manager.createNotificationChannel(channel)

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationChannel.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationChannel.kt
@@ -16,12 +16,21 @@ object LiveUpdateNotificationChannel {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = context.getSystemService<NotificationManager>() ?: return
         val channelId = channelIdFor(activityType)
-        if (manager.getNotificationChannel(channelId) != null) return
+
+        // Migrate existing HIGH-importance channel down to DEFAULT to stop heads-up re-popping
+        val existing = manager.getNotificationChannel(channelId)
+        if (existing != null) {
+            if (existing.importance == NotificationManager.IMPORTANCE_HIGH) {
+                manager.deleteNotificationChannel(channelId)
+            } else {
+                return
+            }
+        }
 
         val channel = NotificationChannel(
             channelId,
             channelName(context, activityType),
-            NotificationManager.IMPORTANCE_HIGH,
+            NotificationManager.IMPORTANCE_DEFAULT,
         ).apply {
             description = channelDescription(context, activityType)
             enableVibration(false)

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationReceiver.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationReceiver.kt
@@ -186,7 +186,7 @@ class LiveUpdateNotificationReceiver : BroadcastReceiver() {
             PendingIntent.getActivity(context, 0, it, PendingIntent.FLAG_IMMUTABLE)
         }
 
-        val destinationIcon = getDestinationIcon(destination)
+        val destinationIcon = TravelLiveUpdateAssets.trackerIconFor(destination)
         val timeFormat = android.text.format.DateFormat.getTimeFormat(context)
         val nowFormatted = timeFormat.format(java.util.Date())
 
@@ -226,17 +226,6 @@ class LiveUpdateNotificationReceiver : BroadcastReceiver() {
         route?.let { builder.setSubText(it) }
 
         androidx.core.app.NotificationManagerCompat.from(context).notify(sessionId.hashCode(), builder.build())
-    }
-
-    /**
-     * Returns the appropriate drawable resource ID for the given travel destination
-     * Uses plane_left when returning to Torn, plane_right when traveling abroad
-     */
-    private fun getDestinationIcon(destination: String?): Int {
-        return when (destination?.lowercase()) {
-            "torn" -> com.manuito.tornpda.R.drawable.plane_left
-            else -> com.manuito.tornpda.R.drawable.plane_right
-        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdatePlugin.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdatePlugin.kt
@@ -25,6 +25,7 @@ object LiveUpdatePlugin {
             travelManager = travelManager,
             racingManager = racingManager,
             eventEmitter = MethodChannelEventEmitter(channel),
+            context = appContext,
         )
         channel.setMethodCallHandler(bridge)
 

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateSessionRegistry.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateSessionRegistry.kt
@@ -9,6 +9,7 @@ data class LiveUpdateSessionState(
     val contentIdentifier: String?,
     val startedAtMs: Long,
     val lastUpdatedAtMs: Long,
+    val lastHasArrived: Boolean = false,
 )
 
 interface LiveUpdateSessionStore {
@@ -37,6 +38,7 @@ class LiveUpdateSessionRegistry(
             .putString(KEY_CONTENT_IDENTIFIER, state.contentIdentifier)
             .putLong(KEY_STARTED_AT, state.startedAtMs)
             .putLong(KEY_LAST_UPDATED_AT, state.lastUpdatedAtMs)
+            .putBoolean(KEY_LAST_HAS_ARRIVED, state.lastHasArrived)
             .apply()
     }
 
@@ -57,12 +59,14 @@ class LiveUpdateSessionRegistry(
         val storedType = LiveUpdateActivityType.fromWireName(prefs.getString(KEY_ACTIVITY_TYPE, activityType.wireName))
         val contentIdentifier = prefs.getString(KEY_CONTENT_IDENTIFIER, null)
             ?: if (storedType == LiveUpdateActivityType.TRAVEL) prefs.getString(KEY_LEGACY_TRAVEL_IDENTIFIER, null) else null
+        val lastHasArrived = prefs.getBoolean(KEY_LAST_HAS_ARRIVED, false)
         return LiveUpdateSessionState(
             sessionId = sessionId,
             activityType = storedType,
             contentIdentifier = contentIdentifier,
             startedAtMs = startedAt,
             lastUpdatedAtMs = lastUpdated,
+            lastHasArrived = lastHasArrived,
         )
     }
 
@@ -74,5 +78,6 @@ class LiveUpdateSessionRegistry(
         private const val KEY_LEGACY_TRAVEL_IDENTIFIER = "travel_identifier"
         private const val KEY_STARTED_AT = "started_at"
         private const val KEY_LAST_UPDATED_AT = "last_updated_at"
+        private const val KEY_LAST_HAS_ARRIVED = "last_has_arrived"
     }
 }

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssets.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssets.kt
@@ -1,0 +1,31 @@
+package com.manuito.tornpda.liveupdates
+
+import com.manuito.tornpda.R
+
+object TravelLiveUpdateAssets {
+
+    fun flagIconFor(displayName: String?): Int {
+        return when (displayName?.trim()?.lowercase()) {
+            "torn" -> R.drawable.action_torn
+            "argentina" -> R.drawable.flag_argentina
+            "canada" -> R.drawable.flag_canada
+            "cayman islands", "cayman", "cayman island" -> R.drawable.flag_cayman
+            "china" -> R.drawable.flag_china
+            "hawaii" -> R.drawable.flag_hawaii
+            "japan" -> R.drawable.flag_japan
+            "mexico" -> R.drawable.flag_mexico
+            "south africa" -> R.drawable.flag_south_africa
+            "switzerland" -> R.drawable.flag_switzerland
+            "uae", "united arab emirates" -> R.drawable.flag_uae
+            "united kingdom", "uk" -> R.drawable.flag_uk
+            else -> R.drawable.plane_right
+        }
+    }
+
+    fun trackerIconFor(destinationDisplayName: String?): Int {
+        return when (destinationDisplayName?.trim()?.lowercase()) {
+            "torn" -> R.drawable.plane_left
+            else -> R.drawable.plane_right
+        }
+    }
+}

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
@@ -65,7 +65,7 @@ class TravelLiveUpdateNotificationFactory(
         dismissIntent: android.app.PendingIntent,
     ): Notification {
         val hasActuallyArrived = contentBuilder.hasActuallyArrived(payload)
-        val destinationIcon = getDestinationIcon(payload.currentDestinationDisplayName)
+        val destinationIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
         val remainingText = formatRemaining(payload)
         val earliestReturnText = formatEarliestReturn(payload)
         val arrivalClockTime = formatArrivalClockTime(payload)
@@ -152,7 +152,7 @@ class TravelLiveUpdateNotificationFactory(
         dismissIntent: android.app.PendingIntent,
     ): Notification {
         val hasActuallyArrived = contentBuilder.hasActuallyArrived(payload)
-        val destinationIcon = getDestinationIcon(payload.currentDestinationDisplayName)
+        val destinationIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
         val remainingText = formatRemaining(payload)
         val earliestReturnText = formatEarliestReturn(payload)
         val arrivalClockTime = formatArrivalClockTime(payload)
@@ -301,13 +301,7 @@ class TravelLiveUpdateNotificationFactory(
         }
     }
 
-    /**
-     * Configures `Notification.ProgressStyle` (Android 16+, the canonical
-     * "tracker" UI for start→end journeys). Returns `true` when applied so
-     * the caller can skip the BigTextStyle fallback. Reflective so the build
-     * still compiles and runs cleanly on devices/SDKs where the API isn't
-     * yet present (developer previews, OEM forks, etc.).
-     */
+    // Reflective because compileSdk may be below 36 (ProgressStyle is Android 16+).
     @SuppressLint("NewApi")
     private fun applyProgressStyleIfAvailable(
         builder: Notification.Builder,
@@ -316,6 +310,7 @@ class TravelLiveUpdateNotificationFactory(
     ): Boolean {
         if (Build.VERSION.SDK_INT < 36) return false
         progress ?: return false
+        val refs = ProgressStyleRefs.resolve() ?: return false
 
         val total = progress.totalSeconds.toInt().coerceAtLeast(1)
         val elapsed = progress.elapsedSeconds.toInt().coerceIn(0, total)
@@ -324,25 +319,13 @@ class TravelLiveUpdateNotificationFactory(
         val trackerIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
 
         return try {
-            val styleClass = Class.forName("android.app.Notification\$ProgressStyle")
-            val style = styleClass.getDeclaredConstructor().newInstance()
-
-            styleClass.getMethod("setProgress", Int::class.javaPrimitiveType)
-                .invoke(style, elapsed)
-            styleClass.getMethod("setProgressTrackerIcon", Icon::class.java)
-                .invoke(style, Icon.createWithResource(context, trackerIcon))
-            styleClass.getMethod("setProgressStartIcon", Icon::class.java)
-                .invoke(style, Icon.createWithResource(context, originIcon))
-            styleClass.getMethod("setProgressEndIcon", Icon::class.java)
-                .invoke(style, Icon.createWithResource(context, destinationIcon))
-
-            val segmentClass = Class.forName("android.app.Notification\$ProgressStyle\$Segment")
-            val segment = segmentClass
-                .getDeclaredConstructor(Int::class.javaPrimitiveType)
-                .newInstance(total)
-            styleClass.getMethod("addProgressSegment", segmentClass)
-                .invoke(style, segment)
-
+            val style = refs.styleCtor.newInstance()
+            refs.setProgress.invoke(style, elapsed)
+            refs.setTrackerIcon.invoke(style, Icon.createWithResource(context, trackerIcon))
+            refs.setStartIcon.invoke(style, Icon.createWithResource(context, originIcon))
+            refs.setEndIcon.invoke(style, Icon.createWithResource(context, destinationIcon))
+            val segment = refs.segmentCtor.newInstance(total)
+            refs.addSegment.invoke(style, segment)
             builder.setStyle(style as Notification.Style)
             true
         } catch (t: Throwable) {
@@ -354,13 +337,14 @@ class TravelLiveUpdateNotificationFactory(
     @SuppressLint("NewApi")
     private fun warnIfNotPromotable(notification: Notification) {
         if (Build.VERSION.SDK_INT < 36) return
+        val method = PromotableRef.resolve(notification.javaClass) ?: return
         try {
-            val method = notification.javaClass.getMethod("hasPromotableCharacteristics")
             val promotable = method.invoke(notification) as? Boolean ?: return
             if (!promotable) {
                 Log.w(TAG, "Live Update notification did not qualify for promotion")
             }
-        } catch (_: Throwable) {
+        } catch (t: Throwable) {
+            Log.d(TAG, "hasPromotableCharacteristics invocation failed", t)
         }
     }
 
@@ -380,15 +364,66 @@ class TravelLiveUpdateNotificationFactory(
         }
     }
 
-    private fun getDestinationIcon(destination: String?): Int {
-        return when (destination?.lowercase()) {
-            "torn" -> R.drawable.plane_left
-            else -> R.drawable.plane_right
+    companion object {
+        private const val TAG = "TravelLiveUpdate"
+    }
+
+    private class ProgressStyleRefs(
+        val styleCtor: java.lang.reflect.Constructor<*>,
+        val segmentCtor: java.lang.reflect.Constructor<*>,
+        val setProgress: java.lang.reflect.Method,
+        val setTrackerIcon: java.lang.reflect.Method,
+        val setStartIcon: java.lang.reflect.Method,
+        val setEndIcon: java.lang.reflect.Method,
+        val addSegment: java.lang.reflect.Method,
+    ) {
+        companion object {
+            @Volatile
+            private var cached: ProgressStyleRefs? = null
+
+            @Volatile
+            private var unavailable = false
+
+            fun resolve(): ProgressStyleRefs? {
+                cached?.let { return it }
+                if (unavailable) return null
+                return try {
+                    val styleClass = Class.forName("android.app.Notification\$ProgressStyle")
+                    val segmentClass = Class.forName("android.app.Notification\$ProgressStyle\$Segment")
+                    ProgressStyleRefs(
+                        styleCtor = styleClass.getDeclaredConstructor(),
+                        segmentCtor = segmentClass.getDeclaredConstructor(Int::class.javaPrimitiveType),
+                        setProgress = styleClass.getMethod("setProgress", Int::class.javaPrimitiveType),
+                        setTrackerIcon = styleClass.getMethod("setProgressTrackerIcon", Icon::class.java),
+                        setStartIcon = styleClass.getMethod("setProgressStartIcon", Icon::class.java),
+                        setEndIcon = styleClass.getMethod("setProgressEndIcon", Icon::class.java),
+                        addSegment = styleClass.getMethod("addProgressSegment", segmentClass),
+                    ).also { cached = it }
+                } catch (_: Throwable) {
+                    unavailable = true
+                    null
+                }
+            }
         }
     }
 
-    companion object {
-        private const val TAG = "TravelLiveUpdate"
+    private object PromotableRef {
+        @Volatile
+        private var cached: java.lang.reflect.Method? = null
+
+        @Volatile
+        private var unavailable = false
+
+        fun resolve(notificationClass: Class<*>): java.lang.reflect.Method? {
+            cached?.let { return it }
+            if (unavailable) return null
+            return try {
+                notificationClass.getMethod("hasPromotableCharacteristics").also { cached = it }
+            } catch (_: Throwable) {
+                unavailable = true
+                null
+            }
+        }
     }
 
     private fun LiveUpdatePayload.toExtrasBundle(): android.os.Bundle {

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
@@ -3,7 +3,9 @@ package com.manuito.tornpda.liveupdates
 import android.annotation.SuppressLint
 import android.app.Notification
 import android.content.Context
+import android.graphics.drawable.Icon
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.manuito.tornpda.R
 
@@ -197,19 +199,25 @@ class TravelLiveUpdateNotificationFactory(
             builder.setContentTitle("$title $destination")
             builder.setContentText(contentTextParts.joinToString(" • "))
             builder.setSubText(secondary)
-            builder.setStyle(
-                Notification.BigTextStyle().bigText(
-                    buildList {
-                        add(secondary)
-                        add(contentTextParts.joinToString(" • "))
-                        earliestReturnText?.let { add(it) }
-                    }.joinToString("\n"),
-                ),
-            )
 
-            contentBuilder.computeProgress(payload)?.let {
-                builder.setProgress(it.totalSeconds.toInt(), it.elapsedSeconds.toInt(), false)
-            } ?: builder.setProgress(0, 0, false)
+            val progressInfo = contentBuilder.computeProgress(payload)
+            val styleApplied = applyProgressStyleIfAvailable(builder, payload, progressInfo)
+            if (!styleApplied) {
+                builder.setStyle(
+                    Notification.BigTextStyle().bigText(
+                        buildList {
+                            add(secondary)
+                            add(contentTextParts.joinToString(" • "))
+                            earliestReturnText?.let { add(it) }
+                        }.joinToString("\n"),
+                    ),
+                )
+                if (progressInfo != null) {
+                    builder.setProgress(progressInfo.totalSeconds.toInt(), progressInfo.elapsedSeconds.toInt(), false)
+                } else {
+                    builder.setProgress(0, 0, false)
+                }
+            }
 
             val arrivalMillis = (payload.arrivalTimeTimestamp ?: 0L) * 1000
             if (arrivalMillis > 0) {
@@ -222,7 +230,9 @@ class TravelLiveUpdateNotificationFactory(
             }
         }
 
-        return builder.build()
+        val notification = builder.build()
+        warnIfNotPromotable(notification)
+        return notification
     }
 
     private fun formatEta(payload: LiveUpdatePayload): String {
@@ -291,6 +301,69 @@ class TravelLiveUpdateNotificationFactory(
         }
     }
 
+    /**
+     * Configures `Notification.ProgressStyle` (Android 16+, the canonical
+     * "tracker" UI for start→end journeys). Returns `true` when applied so
+     * the caller can skip the BigTextStyle fallback. Reflective so the build
+     * still compiles and runs cleanly on devices/SDKs where the API isn't
+     * yet present (developer previews, OEM forks, etc.).
+     */
+    @SuppressLint("NewApi")
+    private fun applyProgressStyleIfAvailable(
+        builder: Notification.Builder,
+        payload: LiveUpdatePayload,
+        progress: LiveUpdateNotificationContentBuilder.ProgressInfo?,
+    ): Boolean {
+        if (Build.VERSION.SDK_INT < 36) return false
+        progress ?: return false
+
+        val total = progress.totalSeconds.toInt().coerceAtLeast(1)
+        val elapsed = progress.elapsedSeconds.toInt().coerceIn(0, total)
+        val originIcon = TravelLiveUpdateAssets.flagIconFor(payload.originDisplayName)
+        val destinationIcon = TravelLiveUpdateAssets.flagIconFor(payload.currentDestinationDisplayName)
+        val trackerIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
+
+        return try {
+            val styleClass = Class.forName("android.app.Notification\$ProgressStyle")
+            val style = styleClass.getDeclaredConstructor().newInstance()
+
+            styleClass.getMethod("setProgress", Int::class.javaPrimitiveType)
+                .invoke(style, elapsed)
+            styleClass.getMethod("setProgressTrackerIcon", Icon::class.java)
+                .invoke(style, Icon.createWithResource(context, trackerIcon))
+            styleClass.getMethod("setProgressStartIcon", Icon::class.java)
+                .invoke(style, Icon.createWithResource(context, originIcon))
+            styleClass.getMethod("setProgressEndIcon", Icon::class.java)
+                .invoke(style, Icon.createWithResource(context, destinationIcon))
+
+            val segmentClass = Class.forName("android.app.Notification\$ProgressStyle\$Segment")
+            val segment = segmentClass
+                .getDeclaredConstructor(Int::class.javaPrimitiveType)
+                .newInstance(total)
+            styleClass.getMethod("addProgressSegment", segmentClass)
+                .invoke(style, segment)
+
+            builder.setStyle(style as Notification.Style)
+            true
+        } catch (t: Throwable) {
+            Log.w(TAG, "ProgressStyle unavailable, falling back to BigTextStyle", t)
+            false
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private fun warnIfNotPromotable(notification: Notification) {
+        if (Build.VERSION.SDK_INT < 36) return
+        try {
+            val method = notification.javaClass.getMethod("hasPromotableCharacteristics")
+            val promotable = method.invoke(notification) as? Boolean ?: return
+            if (!promotable) {
+                Log.w(TAG, "Live Update notification did not qualify for promotion")
+            }
+        } catch (_: Throwable) {
+        }
+    }
+
     private fun invokeFrameworkShortCriticalText(builder: Notification.Builder, text: CharSequence) {
         try {
             val extras = android.os.Bundle().apply {
@@ -312,6 +385,10 @@ class TravelLiveUpdateNotificationFactory(
             "torn" -> R.drawable.plane_left
             else -> R.drawable.plane_right
         }
+    }
+
+    companion object {
+        private const val TAG = "TravelLiveUpdate"
     }
 
     private fun LiveUpdatePayload.toExtrasBundle(): android.os.Bundle {

--- a/android/app/src/test/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManagerTest.kt
+++ b/android/app/src/test/java/com/manuito/tornpda/liveupdates/DefaultLiveUpdateManagerTest.kt
@@ -51,7 +51,7 @@ class DefaultLiveUpdateManagerTest {
         assertTrue(sessionStore.isActive())
 
         adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.UPDATED)
-        val secondResult = manager.startOrUpdate(payload())
+        val secondResult = manager.startOrUpdate(payload(hasArrived = true))
         assertEquals("session-xyz", secondResult.sessionId)
         assertEquals(2, adapter.startCalls)
     }
@@ -91,11 +91,69 @@ class DefaultLiveUpdateManagerTest {
         assertFalse(sessionStore.isActive())
     }
 
-    private fun payload(): Map<String, Any?> {
+    @Test
+    fun startWithIdenticalTravelStateSkipsAdapter() {
+        val eligibility = FakeEligibilityProvider(successResult())
+        val adapter = RecordingAdapter()
+        val sessionStore = RecordingSessionStore()
+        val manager = DefaultLiveUpdateManager(LiveUpdateActivityType.TRAVEL, adapter, eligibility, sessionStore) { "session-dedup" }
+
+        adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.STARTED)
+        manager.startOrUpdate(payload(hasArrived = false))
+        assertEquals(1, adapter.startCalls)
+
+        // Second identical call — same trip, same state (en-route)
+        adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.UPDATED)
+        val result = manager.startOrUpdate(payload(hasArrived = false))
+        assertEquals(LiveUpdateRequestStatus.UPDATED, result.status)
+        assertEquals("session-dedup", result.sessionId)
+        // Adapter must NOT be called again
+        assertEquals(1, adapter.startCalls)
+    }
+
+    @Test
+    fun startTransitionToArrivedCallsAdapter() {
+        val eligibility = FakeEligibilityProvider(successResult())
+        val adapter = RecordingAdapter()
+        val sessionStore = RecordingSessionStore()
+        val manager = DefaultLiveUpdateManager(LiveUpdateActivityType.TRAVEL, adapter, eligibility, sessionStore) { "session-arrive" }
+
+        adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.STARTED)
+        manager.startOrUpdate(payload(hasArrived = false))
+        assertEquals(1, adapter.startCalls)
+
+        // Transition to arrived — adapter MUST be called
+        adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.UPDATED)
+        manager.startOrUpdate(payload(hasArrived = true))
+        assertEquals(2, adapter.startCalls)
+    }
+
+    @Test
+    fun startWithDifferentTripCallsAdapter() {
+        val eligibility = FakeEligibilityProvider(successResult())
+        val adapter = RecordingAdapter()
+        val sessionStore = RecordingSessionStore()
+        val manager = DefaultLiveUpdateManager(LiveUpdateActivityType.TRAVEL, adapter, eligibility, sessionStore) { "session-trips" }
+
+        adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.STARTED)
+        manager.startOrUpdate(payload(travelIdentifier = "trip-A"))
+        assertEquals(1, adapter.startCalls)
+
+        // Different trip — adapter MUST be called
+        adapter.nextResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.UPDATED)
+        manager.startOrUpdate(payload(travelIdentifier = "trip-B"))
+        assertEquals(2, adapter.startCalls)
+    }
+
+    private fun payload(
+        hasArrived: Boolean = false,
+        travelIdentifier: String = "torn-1700",
+    ): Map<String, Any?> {
         return mapOf(
             "arrivalTimeTimestamp" to 1700L,
             "departureTimeTimestamp" to 1600L,
-            "travelIdentifier" to "torn-1700",
+            "travelIdentifier" to travelIdentifier,
+            "hasArrived" to hasArrived,
         )
     }
 
@@ -119,9 +177,11 @@ class DefaultLiveUpdateManagerTest {
         var endCalls = 0
         var adapterListener: LiveUpdateAdapterListener? = null
         var nextResult: LiveUpdateAdapterResult = LiveUpdateAdapterResult(LiveUpdateRequestStatus.STARTED)
+        var lastPayload: LiveUpdatePayload? = null
 
         override fun startOrUpdate(sessionId: String, payload: LiveUpdatePayload): LiveUpdateAdapterResult {
             startCalls += 1
+            lastPayload = payload
             return nextResult
         }
 

--- a/android/app/src/test/java/com/manuito/tornpda/liveupdates/LiveUpdateChannelBridgeTest.kt
+++ b/android/app/src/test/java/com/manuito/tornpda/liveupdates/LiveUpdateChannelBridgeTest.kt
@@ -13,7 +13,7 @@ class LiveUpdateChannelBridgeTest {
     fun startCallReturnsStructuredResult() {
         val manager = FakeManager()
         val emitter = RecordingEmitter()
-        val bridge = LiveUpdateChannelBridge(manager, emitter)
+        val bridge = LiveUpdateChannelBridge(manager, manager, emitter)
 
         val call = MethodCall("startTravelActivity", mapOf("foo" to "bar"))
         val result = RecordingResult()
@@ -34,7 +34,7 @@ class LiveUpdateChannelBridgeTest {
     fun endCallPassesSessionId() {
         val manager = FakeManager()
         val emitter = RecordingEmitter()
-        val bridge = LiveUpdateChannelBridge(manager, emitter)
+        val bridge = LiveUpdateChannelBridge(manager, manager, emitter)
 
         val call = MethodCall("endTravelActivity", mapOf("sessionId" to "session-123"))
         val result = RecordingResult()
@@ -50,7 +50,7 @@ class LiveUpdateChannelBridgeTest {
     fun capabilityRequestsReturnCachedSnapshot() {
         val manager = FakeManager()
         val emitter = RecordingEmitter()
-        val bridge = LiveUpdateChannelBridge(manager, emitter)
+        val bridge = LiveUpdateChannelBridge(manager, manager, emitter)
 
         val result = RecordingResult()
         bridge.onMethodCall(MethodCall("getLiveUpdateCapabilities", null), result)
@@ -63,7 +63,7 @@ class LiveUpdateChannelBridgeTest {
     fun managerEventsEmitThroughEmitter() {
         val manager = FakeManager()
         val emitter = RecordingEmitter()
-        val bridge = LiveUpdateChannelBridge(manager, emitter)
+        val bridge = LiveUpdateChannelBridge(manager, manager, emitter)
 
         manager.emitStatus()
         manager.emitCapability()
@@ -84,7 +84,7 @@ class LiveUpdateChannelBridgeTest {
     fun unknownMethodReturnsNotImplemented() {
         val manager = FakeManager()
         val emitter = RecordingEmitter()
-        val bridge = LiveUpdateChannelBridge(manager, emitter)
+        val bridge = LiveUpdateChannelBridge(manager, manager, emitter)
 
         val result = RecordingResult()
         bridge.onMethodCall(MethodCall("unknown", null), result)

--- a/android/app/src/test/java/com/manuito/tornpda/liveupdates/LiveUpdateEligibilityEvaluatorTest.kt
+++ b/android/app/src/test/java/com/manuito/tornpda/liveupdates/LiveUpdateEligibilityEvaluatorTest.kt
@@ -57,6 +57,22 @@ class LiveUpdateEligibilityEvaluatorTest {
     }
 
     @Test
+    fun promotedNotificationsDisabledProducesPromotedDisabledReason() {
+        val evaluator = createEvaluator(
+            apiLevel = 40,
+            notificationsAllowed = true,
+            promotedNotificationsAllowed = false,
+            batteryOptimized = false,
+        )
+
+        val result = evaluator.evaluate()
+
+        assertFalse(result.eligible)
+        assertEquals(LiveUpdateUnsupportedReason.PROMOTED_DISABLED, result.reason)
+        assertFalse(result.snapshot.promotedNotificationsEnabled)
+    }
+
+    @Test
     fun eligibleSnapshotIncludesVendor() {
         val evaluator = createEvaluator(
             apiLevel = 40,
@@ -76,6 +92,7 @@ class LiveUpdateEligibilityEvaluatorTest {
         cache: InMemoryCapabilityCache = InMemoryCapabilityCache(),
         apiLevel: Int,
         notificationsAllowed: Boolean,
+        promotedNotificationsAllowed: Boolean = true,
         batteryOptimized: Boolean,
         vendor: String = "Pixel",
     ): LiveUpdateEligibilityEvaluator {
@@ -86,6 +103,7 @@ class LiveUpdateEligibilityEvaluatorTest {
             requiredApiLevel = 35,
             apiLevelProvider = { apiLevel },
             notificationsAllowedProvider = { notificationsAllowed },
+            promotedNotificationsAllowedProvider = { promotedNotificationsAllowed },
             batteryOptimizedProvider = { batteryOptimized },
             vendorProvider = { vendor },
         )

--- a/android/app/src/test/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssetsTest.kt
+++ b/android/app/src/test/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssetsTest.kt
@@ -1,0 +1,41 @@
+package com.manuito.tornpda.liveupdates
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TravelLiveUpdateAssetsTest {
+
+    @Test
+    fun flagIconForKnownDestinationsReturnsDistinctDrawables() {
+        val destinations = listOf(
+            "Argentina", "Canada", "Cayman Islands", "China", "Hawaii",
+            "Japan", "Mexico", "South Africa", "Switzerland", "UAE", "United Kingdom", "Torn",
+        )
+        val icons = destinations.map { TravelLiveUpdateAssets.flagIconFor(it) }.toSet()
+        assertEquals("each known destination maps to a unique drawable", destinations.size, icons.size)
+    }
+
+    @Test
+    fun flagIconForHandlesCaseAndWhitespace() {
+        assertEquals(
+            TravelLiveUpdateAssets.flagIconFor("Mexico"),
+            TravelLiveUpdateAssets.flagIconFor("  mexico  "),
+        )
+    }
+
+    @Test
+    fun flagIconForUnknownFallsBackToDefault() {
+        val unknown = TravelLiveUpdateAssets.flagIconFor("Atlantis")
+        val mexico = TravelLiveUpdateAssets.flagIconFor("Mexico")
+        assertNotEquals(mexico, unknown)
+    }
+
+    @Test
+    fun trackerIconFlipsForHomewardTrip() {
+        assertNotEquals(
+            TravelLiveUpdateAssets.trackerIconFor("Mexico"),
+            TravelLiveUpdateAssets.trackerIconFor("Torn"),
+        )
+    }
+}

--- a/lib/pages/alerts/alerts_troubleshooting_page.dart
+++ b/lib/pages/alerts/alerts_troubleshooting_page.dart
@@ -1110,6 +1110,8 @@ class _AlertsTroubleshootingPageState extends State<AlertsTroubleshootingPage> {
         return "OEM capsule unavailable";
       case LiveUpdateUnsupportedReason.permissionDenied:
         return "Permission denied";
+      case LiveUpdateUnsupportedReason.promotedDisabled:
+        return "Promoted notifications disabled";
       case LiveUpdateUnsupportedReason.batteryRestricted:
         return "Battery optimization";
       case LiveUpdateUnsupportedReason.internalError:

--- a/lib/utils/live_activities/live_activity_bridge.dart
+++ b/lib/utils/live_activities/live_activity_bridge.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get_state_manager/src/simple/get_controllers.dart';
@@ -192,6 +193,20 @@ class LiveActivityBridgeController extends GetxController {
       log("LiveActivityBridgeService: Error getting capability snapshot: $e");
     }
     return _latestCapabilitySnapshot;
+  }
+
+  /// Opens the system settings page that lets the user toggle promoted
+  /// notifications for this app (Android 16+). Returns `false` when the
+  /// platform/route can't be resolved.
+  Future<bool> openPromotedNotificationsSettings() async {
+    if (!Platform.isAndroid) return false;
+    try {
+      final dynamic response = await _channel.invokeMethod('openPromotedNotificationsSettings');
+      return response == true;
+    } catch (e) {
+      log("LiveActivityBridgeService: Error opening promoted notifications settings: $e");
+      return false;
+    }
   }
 
   Future<void> getPushToStartTokenAndSendToFirebase({

--- a/lib/utils/live_activities/live_activity_bridge.dart
+++ b/lib/utils/live_activities/live_activity_bridge.dart
@@ -195,9 +195,7 @@ class LiveActivityBridgeController extends GetxController {
     return _latestCapabilitySnapshot;
   }
 
-  /// Opens the system settings page that lets the user toggle promoted
-  /// notifications for this app (Android 16+). Returns `false` when the
-  /// platform/route can't be resolved.
+  /// Android 16+: returns `false` on older SDKs or when the route can't be resolved.
   Future<bool> openPromotedNotificationsSettings() async {
     if (!Platform.isAndroid) return false;
     try {

--- a/lib/utils/live_activities/live_activity_travel_controller.dart
+++ b/lib/utils/live_activities/live_activity_travel_controller.dart
@@ -29,6 +29,7 @@ class LiveActivityTravelController extends GetxController {
   String _lastArrivalNotifiedTravelId = "";
   bool _hasArrivedNotified = false;
 
+  Completer<void>? _processGuard;
   bool _isMonitoring = false;
   Worker? _statusListenerWorker;
   StreamSubscription<LiveUpdateStatusEvent>? _statusEventSubscription;
@@ -37,6 +38,28 @@ class LiveActivityTravelController extends GetxController {
   static const int _arrivedLAAutoEndMinutes = 10;
   static const String _backupTaskUniqueName = "com.tornpda.liveactivity.arrival_backup";
   String? _activeSessionId;
+
+  @visibleForTesting
+  static Map<String, int> computeDeviceRelativeTimestamps({
+    required int serverArrivalTimestamp,
+    required int serverDepartureTimestamp,
+    required int? timeLeftSeconds,
+    required int deviceNowSeconds,
+  }) {
+    if (timeLeftSeconds != null && timeLeftSeconds > 0) {
+      final deviceArrival = deviceNowSeconds + timeLeftSeconds;
+      final totalDuration = serverArrivalTimestamp - serverDepartureTimestamp;
+      final deviceDeparture = deviceArrival - totalDuration;
+      return {
+        'arrivalTimestamp': deviceArrival,
+        'departureTimestamp': deviceDeparture,
+      };
+    }
+    return {
+      'arrivalTimestamp': serverArrivalTimestamp,
+      'departureTimestamp': serverDepartureTimestamp,
+    };
+  }
 
   @visibleForTesting
   bool get isLiveActivityActiveForTest => _isLALogicallyActive;
@@ -133,6 +156,7 @@ class LiveActivityTravelController extends GetxController {
           'destination': travel.destination!,
           'arrivalTimestamp': travel.timestamp!,
           'departureTimestamp': travel.departed!,
+          'timeLeft': travel.timeLeft,
         };
       }
     }
@@ -176,6 +200,12 @@ class LiveActivityTravelController extends GetxController {
       return;
     }
 
+    if (_processGuard != null && !_processGuard!.isCompleted) {
+      return; // skip concurrent call
+    }
+    _processGuard = Completer<void>();
+
+    try {
     bool isConsideredFirstValidRun = false;
     final apiData = _getCurrentTravelDataFromApi(statusData?.barsAndStatusModel);
 
@@ -294,6 +324,12 @@ class LiveActivityTravelController extends GetxController {
     // --- Perform the LA start/update if decided
     if (shouldStartOrUpdateLA && laArgs != null) {
       final bool isArrivalUpdate = laArgs['hasArrived'] == true;
+
+      // Optimistic state update before await to prevent duplicate calls
+      _isLALogicallyActive = true;
+      _lastProcessedTravelIdentifier = travelId;
+      _currentLAArrivalTimestamp = arrivalTimestamp;
+
       // log("TravelLiveActivityHandler: Calling bridge to start/update LA with args: $laArgs");
       final LiveUpdateStartResult result = await _bridgeController.startActivity(arguments: laArgs);
       applyStartResult(result);
@@ -301,8 +337,6 @@ class LiveActivityTravelController extends GetxController {
         log("TravelLiveActivityHandler: Native layer reported ${result.status} (${result.reason})");
         return;
       }
-      _currentLAArrivalTimestamp = arrivalTimestamp;
-      _lastProcessedTravelIdentifier = travelId;
       if (isArrivalUpdate) {
         _lastArrivalNotifiedTravelId = travelId;
         if (Platform.isAndroid) {
@@ -326,6 +360,9 @@ class LiveActivityTravelController extends GetxController {
         }
       }
     }
+    } finally {
+      _processGuard?.complete();
+    }
   }
 
   // Does not end the native Live Activity, just resets the internal state
@@ -336,6 +373,7 @@ class LiveActivityTravelController extends GetxController {
     _isLALogicallyActive = false;
     _activeSessionId = null;
     _currentLAArrivalTimestamp = 0;
+    _lastProcessedTravelIdentifier = "";
     _hasArrivedNotified = false;
 
     if (Platform.isAndroid) {
@@ -406,6 +444,28 @@ class LiveActivityTravelController extends GetxController {
 
     final int currentDeviceTimestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
 
+    int arrivalTimeForNotification = apiTravelData['arrivalTimestamp']!;
+    int departureTimeForNotification = apiTravelData['departureTimestamp']!;
+
+    if (!hasArrived && Platform.isAndroid) {
+      final deviceTimestamps = computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: apiTravelData['arrivalTimestamp']!,
+        serverDepartureTimestamp: apiTravelData['departureTimestamp']!,
+        timeLeftSeconds: apiTravelData['timeLeft'],
+        deviceNowSeconds: currentDeviceTimestamp,
+      );
+      arrivalTimeForNotification = deviceTimestamps['arrivalTimestamp']!;
+      departureTimeForNotification = deviceTimestamps['departureTimestamp']!;
+
+      // Recalculate earliestReturnTimestamp with device-relative arrival
+      if (earliestReturnTimestamp != null) {
+        int travelDuration = apiTravelData['arrivalTimestamp']! - apiTravelData['departureTimestamp']!;
+        if (travelDuration > 0) {
+          earliestReturnTimestamp = arrivalTimeForNotification + travelDuration;
+        }
+      }
+    }
+
     // Reconstruct the travelID to ensure uniqueness in session matching if needed by native side
     // (Though currently native relies largely on sessionID, having this consistent helps)
     String travelId =
@@ -417,8 +477,8 @@ class LiveActivityTravelController extends GetxController {
       'currentDestinationFlagAsset': currentDestinationFlagAsset,
       'originDisplayName': originDisplayName,
       'originFlagAsset': originFlagAsset,
-      'arrivalTimeTimestamp': apiTravelData['arrivalTimestamp']!,
-      'departureTimeTimestamp': apiTravelData['departureTimestamp']!,
+      'arrivalTimeTimestamp': arrivalTimeForNotification,
+      'departureTimeTimestamp': departureTimeForNotification,
       'currentServerTimestamp': currentDeviceTimestamp,
       'vehicleAssetName': vehicleAssetName,
       'earliestReturnTimestamp': earliestReturnTimestamp,

--- a/lib/utils/live_activities/live_activity_travel_controller.dart
+++ b/lib/utils/live_activities/live_activity_travel_controller.dart
@@ -40,7 +40,7 @@ class LiveActivityTravelController extends GetxController {
   String? _activeSessionId;
 
   @visibleForTesting
-  static Map<String, int> computeDeviceRelativeTimestamps({
+  static ({int arrivalTimestamp, int departureTimestamp}) computeDeviceRelativeTimestamps({
     required int serverArrivalTimestamp,
     required int serverDepartureTimestamp,
     required int? timeLeftSeconds,
@@ -50,15 +50,15 @@ class LiveActivityTravelController extends GetxController {
       final deviceArrival = deviceNowSeconds + timeLeftSeconds;
       final totalDuration = serverArrivalTimestamp - serverDepartureTimestamp;
       final deviceDeparture = deviceArrival - totalDuration;
-      return {
-        'arrivalTimestamp': deviceArrival,
-        'departureTimestamp': deviceDeparture,
-      };
+      return (arrivalTimestamp: deviceArrival, departureTimestamp: deviceDeparture);
     }
-    return {
-      'arrivalTimestamp': serverArrivalTimestamp,
-      'departureTimestamp': serverDepartureTimestamp,
-    };
+    return (arrivalTimestamp: serverArrivalTimestamp, departureTimestamp: serverDepartureTimestamp);
+  }
+
+  static String _buildTravelId(Map<String, dynamic> apiData, {required bool isRepatriation}) {
+    var id = "${apiData['destination']}-${apiData['arrivalTimestamp']}-${apiData['departureTimestamp']}";
+    if (isRepatriation) id += "-repat";
+    return id;
   }
 
   @visibleForTesting
@@ -206,160 +206,137 @@ class LiveActivityTravelController extends GetxController {
     _processGuard = Completer<void>();
 
     try {
-    bool isConsideredFirstValidRun = false;
-    final apiData = _getCurrentTravelDataFromApi(statusData?.barsAndStatusModel);
+      bool isConsideredFirstValidRun = false;
+      final apiData = _getCurrentTravelDataFromApi(statusData?.barsAndStatusModel);
 
-    if (_isFirstValidProcessingPending) {
-      if (apiData != null) {
-        // We have valid API data for the first time this activation cycle
-        isConsideredFirstValidRun = true;
-        _isFirstValidProcessingPending = false;
-        // log("TravelLiveActivityHandler: First valid data processing run.");
-      } else {
-        // Still waiting for valid data on the first go, do nothing yet.
+      if (_isFirstValidProcessingPending) {
+        if (apiData != null) {
+          // We have valid API data for the first time this activation cycle
+          isConsideredFirstValidRun = true;
+          _isFirstValidProcessingPending = false;
+        } else {
+          // Still waiting for valid data on the first go, do nothing yet.
+          return;
+        }
+      }
+
+      final currentStatusColor = statusData?.statusColor;
+      final currentModel = statusData?.barsAndStatusModel;
+      final traveling = currentStatusColor == PlayerStatusColor.travel;
+      final repatriating = _isPlayerStatusHospitalizedAndPotentiallyReturning(currentStatusColor, currentModel);
+
+      if (apiData == null) {
+        // If no travel data from API, end any LA that Dart thinks is active
+        if (_isLALogicallyActive) {
+          log("TravelLiveActivityHandler: No API travel data. Ending active LA (if any).");
+          _bridgeController.endActivity(); // Tell native to end
+          _resetLAStateInternal(); // Reset Dart's logical state
+        }
         return;
       }
-    }
 
-    final currentStatusColor = statusData?.statusColor;
-    final currentModel = statusData?.barsAndStatusModel;
-    final traveling = currentStatusColor == PlayerStatusColor.travel;
-    final repatriating = _isPlayerStatusHospitalizedAndPotentiallyReturning(currentStatusColor, currentModel);
+      String travelId = _buildTravelId(apiData, isRepatriation: repatriating);
 
-    if (apiData == null) {
-      // If no travel data from API, end any LA that Dart thinks is active
-      if (_isLALogicallyActive) {
-        log("TravelLiveActivityHandler: No API travel data. Ending active LA (if any).");
-        _bridgeController.endActivity(); // Tell native to end
-        _resetLAStateInternal(); // Reset Dart's logical state
-      }
-      return;
-    }
+      bool shouldStartOrUpdateLA = false;
+      Map<String, dynamic>? laArgs;
 
-    String travelId = "${apiData['destination']}-${apiData['arrivalTimestamp']}-${apiData['departureTimestamp']}";
-    if (repatriating) travelId += "-repat";
+      final nowSeconds = (DateTime.now().millisecondsSinceEpoch / 1000).round();
+      final arrivalTimestamp = apiData['arrivalTimestamp']!;
+      final hasPlayerArrived = nowSeconds >= arrivalTimestamp;
 
-    bool shouldStartOrUpdateLA = false;
-    Map<String, dynamic>? laArgs;
+      // --- Main logic to determine LA action ---
+      if (traveling || repatriating) {
+        // Player is currently traveling or repatriating according to API
+        bool isArrivalStale = hasPlayerArrived && (nowSeconds - arrivalTimestamp) > _staleArrivalThresholdSeconds;
 
-    final nowSeconds = (DateTime.now().millisecondsSinceEpoch / 1000).round();
-    final arrivalTimestamp = apiData['arrivalTimestamp']!;
-    final hasPlayerArrived = nowSeconds >= arrivalTimestamp;
-
-    // --- Main logic to determine LA action ---
-    if (traveling || repatriating) {
-      // Player is currently traveling or repatriating according to API
-      bool isArrivalStale = hasPlayerArrived && (nowSeconds - arrivalTimestamp) > _staleArrivalThresholdSeconds;
-
-      // CASE 0: First valid processing run, player has arrived, and the arrival is "stale"
-      if (isConsideredFirstValidRun && hasPlayerArrived && isArrivalStale) {
-        log("TravelLiveActivityHandler: CASE 0 - Initial valid run, player arrived, arrival is stale ($travelId).");
-        if (_isLALogicallyActive) {
-          // If Dart thinks an LA is active (likely adopted by Swift and it's for this stale trip), end it
-          log("CASE 0.1: Ending stale LA that was likely adopted by native side.");
-          _resetLAState();
-        } else {
-          // No LA was active, and we won't start one for this stale arrival
-          // Mark this stale trip as processed by Dart for this session
-          _hasArrivedNotified = true;
-          _lastProcessedTravelIdentifier = travelId;
-          _currentLAArrivalTimestamp = arrivalTimestamp;
-          log("CASE 0.2: No active LA but Dart processed this stale trip already.");
+        // CASE 0: First valid processing run, player has arrived, and the arrival is "stale"
+        if (isConsideredFirstValidRun && hasPlayerArrived && isArrivalStale) {
+          log("TravelLiveActivityHandler: CASE 0 - Initial valid run, player arrived, arrival is stale ($travelId).");
+          if (_isLALogicallyActive) {
+            log("CASE 0.1: Ending stale LA that was likely adopted by native side.");
+            _resetLAState();
+          } else {
+            _hasArrivedNotified = true;
+            _lastProcessedTravelIdentifier = travelId;
+            _currentLAArrivalTimestamp = arrivalTimestamp;
+            log("CASE 0.2: No active LA but Dart processed this stale trip already.");
+          }
         }
-      }
-      // CASE 1: Player has arrived (and if it's the first valid run, it's not stale), and arrival not yet notified by LA
-      // On Android, we also check _lastArrivalNotifiedTravelId to avoid re-notifying the same arrival after app restart,
-      // BUT if an LA is currently active showing "en route" (_isLALogicallyActive && !_hasArrivedNotified),
-      // we MUST update it to "Arrived" regardless of _lastArrivalNotifiedTravelId
-      else if (hasPlayerArrived &&
-          !_hasArrivedNotified &&
-          (!Platform.isAndroid || travelId != _lastArrivalNotifiedTravelId || _isLALogicallyActive)) {
-        log("TravelLiveActivityHandler: CASE 1 - Arrival detected for ${apiData['destination']}. Preparing 'Arrived' LA.");
-        laArgs = _buildArgs(apiTravelData: apiData, isRepatriation: repatriating, hasArrived: true);
-        shouldStartOrUpdateLA = true;
-        _hasArrivedNotified = true;
-      }
-      // CASE 2: Player is en route (not yet arrived)
-      else if (!hasPlayerArrived) {
-        // Avoid constant calls to native side BUT also restarting LA if user canceled!
-        bool isNewOrDifferentTrip = travelId != _lastProcessedTravelIdentifier;
-        // If an LA was adopted (_isLALogicallyActive=true) but Dart's _currentLAArrivalTimestamp is 0 (or different),
-        // this mismatch will trigger an update/replacement
-        bool arrivalTimeMismatch = _isLALogicallyActive && (arrivalTimestamp != _currentLAArrivalTimestamp);
-        bool noLogicalLA = !_isLALogicallyActive;
-
-        // 1. No LA logically active in Dart.
-        // 2. Or, an LA is active, but its arrival time doesn't match the current API data.
-        // 3. Or, an LA is active, but the trip identifier (dest, arrival, dep) has changed.
-        if (noLogicalLA || arrivalTimeMismatch || (_isLALogicallyActive && isNewOrDifferentTrip)) {
-          String logReason =
-              "Reasons: noLogicalLA=$noLogicalLA, arrivalTimeMismatch=$arrivalTimeMismatch, isNewOrDifferentTripWhileActive=${_isLALogicallyActive && isNewOrDifferentTrip}";
-          log("TravelLiveActivityHandler: CASE 2 - Conditions met to start/update LA for ongoing travel. $logReason");
-          laArgs = _buildArgs(apiTravelData: apiData, isRepatriation: repatriating, hasArrived: false);
+        // CASE 1: Player has arrived (and if it's the first valid run, it's not stale), and arrival not yet notified by LA
+        else if (hasPlayerArrived &&
+            !_hasArrivedNotified &&
+            (!Platform.isAndroid || travelId != _lastArrivalNotifiedTravelId || _isLALogicallyActive)) {
+          log("TravelLiveActivityHandler: CASE 1 - Arrival detected for ${apiData['destination']}. Preparing 'Arrived' LA.");
+          laArgs = _buildArgs(apiTravelData: apiData, isRepatriation: repatriating, hasArrived: true);
           shouldStartOrUpdateLA = true;
-          _hasArrivedNotified = false;
+          _hasArrivedNotified = true;
         }
-      }
-    } else {
-      // CASE 3: Player is NOT traveling or repatriating
-      if (_isLALogicallyActive) {
-        // An LA is active in Dart, but API says player isn't traveling
-        if (_hasArrivedNotified && _currentLAArrivalTimestamp > 0) {
-          // This was an "Arrived" LA
-          // Check if 10 minutes have passed since that arrival
-          int elapsedTimeSinceArrival = nowSeconds - _currentLAArrivalTimestamp;
-          if (elapsedTimeSinceArrival >= (_arrivedLAAutoEndMinutes * 60)) {
-            log("TravelLiveActivityHandler: CASE 3.1 - No longer traveling. 'Arrived' LA was active & 10+ min passed since its arrival. Ending LA.");
+        // CASE 2: Player is en route (not yet arrived)
+        else if (!hasPlayerArrived) {
+          bool isNewOrDifferentTrip = travelId != _lastProcessedTravelIdentifier;
+          bool arrivalTimeMismatch = _isLALogicallyActive && (arrivalTimestamp != _currentLAArrivalTimestamp);
+          bool noLogicalLA = !_isLALogicallyActive;
+
+          if (noLogicalLA || arrivalTimeMismatch || (_isLALogicallyActive && isNewOrDifferentTrip)) {
+            String logReason =
+                "Reasons: noLogicalLA=$noLogicalLA, arrivalTimeMismatch=$arrivalTimeMismatch, isNewOrDifferentTripWhileActive=${_isLALogicallyActive && isNewOrDifferentTrip}";
+            log("TravelLiveActivityHandler: CASE 2 - Conditions met to start/update LA for ongoing travel. $logReason");
+            laArgs = _buildArgs(apiTravelData: apiData, isRepatriation: repatriating, hasArrived: false);
+            shouldStartOrUpdateLA = true;
+            _hasArrivedNotified = false;
+          }
+        }
+      } else {
+        // CASE 3: Player is NOT traveling or repatriating
+        if (_isLALogicallyActive) {
+          if (_hasArrivedNotified && _currentLAArrivalTimestamp > 0) {
+            int elapsedTimeSinceArrival = nowSeconds - _currentLAArrivalTimestamp;
+            if (elapsedTimeSinceArrival >= (_arrivedLAAutoEndMinutes * 60)) {
+              log("TravelLiveActivityHandler: CASE 3.1 - No longer traveling. 'Arrived' LA was active & 10+ min passed since its arrival. Ending LA.");
+              _resetLAState();
+            }
+          } else {
+            log("TravelLiveActivityHandler: CASE 3.2 - No longer traveling. LA was 'En Route' or unknown type. Ending LA immediately.");
             _resetLAState();
           }
-        } else {
-          // LA was active but it wasn't an "Arrived" state (e.g., was "En Route" and trip ended/cancelled),
-          // or we don't have its arrival info.
-          log("TravelLiveActivityHandler: CASE 3.2 - No longer traveling. LA was 'En Route' or unknown type. Ending LA immediately.");
-          _resetLAState();
-        }
-      }
-    }
-
-    // --- Perform the LA start/update if decided
-    if (shouldStartOrUpdateLA && laArgs != null) {
-      final bool isArrivalUpdate = laArgs['hasArrived'] == true;
-
-      // Optimistic state update before await to prevent duplicate calls
-      _isLALogicallyActive = true;
-      _lastProcessedTravelIdentifier = travelId;
-      _currentLAArrivalTimestamp = arrivalTimestamp;
-
-      // log("TravelLiveActivityHandler: Calling bridge to start/update LA with args: $laArgs");
-      final LiveUpdateStartResult result = await _bridgeController.startActivity(arguments: laArgs);
-      applyStartResult(result);
-      if (!result.isSuccess) {
-        log("TravelLiveActivityHandler: Native layer reported ${result.status} (${result.reason})");
-        return;
-      }
-      if (isArrivalUpdate) {
-        _lastArrivalNotifiedTravelId = travelId;
-        if (Platform.isAndroid) {
-          await _prefs.setAndroidLiveActivityTravelLastArrivalId(travelId);
         }
       }
 
-      // Sync with Firebase so that a Cloud Function won't start for this LA
-      log("Syncing arrival timestamp $arrivalTimestamp with server...");
-      _syncTimestamp(arrivalTimestamp);
+      // --- Perform the LA start/update if decided
+      if (shouldStartOrUpdateLA && laArgs != null) {
+        final bool isArrivalUpdate = laArgs['hasArrived'] == true;
 
-      if (Platform.isAndroid) {
+        // Optimistic state update before await to prevent duplicate calls
+        _isLALogicallyActive = true;
+        _lastProcessedTravelIdentifier = travelId;
+        _currentLAArrivalTimestamp = arrivalTimestamp;
+
+        final LiveUpdateStartResult result = await _bridgeController.startActivity(arguments: laArgs);
+        applyStartResult(result);
+        if (!result.isSuccess) {
+          log("TravelLiveActivityHandler: Native layer reported ${result.status} (${result.reason})");
+          return;
+        }
         if (isArrivalUpdate) {
-          // If we are notifying arrival, we don't need the backup task anymore
-          _cancelBackupTask();
-          await _prefs.setLiveActivityCurrentTripBackup(null);
-        } else {
-          // Saving current trip for backup purposes
-          await _prefs.setLiveActivityCurrentTripBackup(jsonEncode(laArgs));
-          _scheduleBackupTask(arrivalTimestamp);
+          _lastArrivalNotifiedTravelId = travelId;
+          if (Platform.isAndroid) {
+            await _prefs.setAndroidLiveActivityTravelLastArrivalId(travelId);
+          }
+        }
+
+        log("Syncing arrival timestamp $arrivalTimestamp with server...");
+        _syncTimestamp(arrivalTimestamp);
+
+        if (Platform.isAndroid) {
+          if (isArrivalUpdate) {
+            _cancelBackupTask();
+            await _prefs.setLiveActivityCurrentTripBackup(null);
+          } else {
+            await _prefs.setLiveActivityCurrentTripBackup(jsonEncode(laArgs));
+            _scheduleBackupTask(arrivalTimestamp);
+          }
         }
       }
-    }
     } finally {
       _processGuard?.complete();
     }
@@ -405,6 +382,7 @@ class LiveActivityTravelController extends GetxController {
     bool showProgressBar = !hasArrived;
 
     bool isChristmasTimeValue = _isChristmas();
+    final int travelDuration = apiTravelData['arrivalTimestamp']! - apiTravelData['departureTimestamp']!;
 
     if (isRepatriation) {
       currentDestinationDisplayName = "Torn";
@@ -433,11 +411,8 @@ class LiveActivityTravelController extends GetxController {
         activityStateTitle = hasArrived ? "Arrived in" : "Traveling to";
         destinationEmoji = _getCountryEmoji(destination);
 
-        if (!hasArrived) {
-          int travelDuration = apiTravelData['arrivalTimestamp']! - apiTravelData['departureTimestamp']!;
-          if (travelDuration > 0) {
-            earliestReturnTimestamp = apiTravelData['arrivalTimestamp']! + travelDuration;
-          }
+        if (!hasArrived && travelDuration > 0) {
+          earliestReturnTimestamp = apiTravelData['arrivalTimestamp']! + travelDuration;
         }
       }
     }
@@ -454,23 +429,16 @@ class LiveActivityTravelController extends GetxController {
         timeLeftSeconds: apiTravelData['timeLeft'],
         deviceNowSeconds: currentDeviceTimestamp,
       );
-      arrivalTimeForNotification = deviceTimestamps['arrivalTimestamp']!;
-      departureTimeForNotification = deviceTimestamps['departureTimestamp']!;
+      arrivalTimeForNotification = deviceTimestamps.arrivalTimestamp;
+      departureTimeForNotification = deviceTimestamps.departureTimestamp;
 
       // Recalculate earliestReturnTimestamp with device-relative arrival
-      if (earliestReturnTimestamp != null) {
-        int travelDuration = apiTravelData['arrivalTimestamp']! - apiTravelData['departureTimestamp']!;
-        if (travelDuration > 0) {
-          earliestReturnTimestamp = arrivalTimeForNotification + travelDuration;
-        }
+      if (earliestReturnTimestamp != null && travelDuration > 0) {
+        earliestReturnTimestamp = arrivalTimeForNotification + travelDuration;
       }
     }
 
-    // Reconstruct the travelID to ensure uniqueness in session matching if needed by native side
-    // (Though currently native relies largely on sessionID, having this consistent helps)
-    String travelId =
-        "${apiTravelData['destination']}-${apiTravelData['arrivalTimestamp']}-${apiTravelData['departureTimestamp']}";
-    if (isRepatriation) travelId += "-repat";
+    String travelId = _buildTravelId(apiTravelData, isRepatriation: isRepatriation);
 
     return {
       'currentDestinationDisplayName': currentDestinationDisplayName,

--- a/lib/utils/live_activities/live_activity_travel_controller.dart
+++ b/lib/utils/live_activities/live_activity_travel_controller.dart
@@ -29,7 +29,7 @@ class LiveActivityTravelController extends GetxController {
   String _lastArrivalNotifiedTravelId = "";
   bool _hasArrivedNotified = false;
 
-  Completer<void>? _processGuard;
+  bool _isProcessing = false;
   bool _isMonitoring = false;
   Worker? _statusListenerWorker;
   StreamSubscription<LiveUpdateStatusEvent>? _statusEventSubscription;
@@ -200,10 +200,8 @@ class LiveActivityTravelController extends GetxController {
       return;
     }
 
-    if (_processGuard != null && !_processGuard!.isCompleted) {
-      return; // skip concurrent call
-    }
-    _processGuard = Completer<void>();
+    if (_isProcessing) return;
+    _isProcessing = true;
 
     try {
       bool isConsideredFirstValidRun = false;
@@ -306,17 +304,14 @@ class LiveActivityTravelController extends GetxController {
       if (shouldStartOrUpdateLA && laArgs != null) {
         final bool isArrivalUpdate = laArgs['hasArrived'] == true;
 
-        // Optimistic state update before await to prevent duplicate calls
-        _isLALogicallyActive = true;
-        _lastProcessedTravelIdentifier = travelId;
-        _currentLAArrivalTimestamp = arrivalTimestamp;
-
         final LiveUpdateStartResult result = await _bridgeController.startActivity(arguments: laArgs);
         applyStartResult(result);
         if (!result.isSuccess) {
           log("TravelLiveActivityHandler: Native layer reported ${result.status} (${result.reason})");
           return;
         }
+        _currentLAArrivalTimestamp = arrivalTimestamp;
+        _lastProcessedTravelIdentifier = travelId;
         if (isArrivalUpdate) {
           _lastArrivalNotifiedTravelId = travelId;
           if (Platform.isAndroid) {
@@ -338,7 +333,7 @@ class LiveActivityTravelController extends GetxController {
         }
       }
     } finally {
-      _processGuard?.complete();
+      _isProcessing = false;
     }
   }
 

--- a/lib/utils/live_activities/live_activity_travel_controller.dart
+++ b/lib/utils/live_activities/live_activity_travel_controller.dart
@@ -209,11 +209,9 @@ class LiveActivityTravelController extends GetxController {
 
       if (_isFirstValidProcessingPending) {
         if (apiData != null) {
-          // We have valid API data for the first time this activation cycle
           isConsideredFirstValidRun = true;
           _isFirstValidProcessingPending = false;
         } else {
-          // Still waiting for valid data on the first go, do nothing yet.
           return;
         }
       }
@@ -224,11 +222,10 @@ class LiveActivityTravelController extends GetxController {
       final repatriating = _isPlayerStatusHospitalizedAndPotentiallyReturning(currentStatusColor, currentModel);
 
       if (apiData == null) {
-        // If no travel data from API, end any LA that Dart thinks is active
         if (_isLALogicallyActive) {
           log("TravelLiveActivityHandler: No API travel data. Ending active LA (if any).");
-          _bridgeController.endActivity(); // Tell native to end
-          _resetLAStateInternal(); // Reset Dart's logical state
+          _bridgeController.endActivity();
+          _resetLAStateInternal();
         }
         return;
       }
@@ -242,9 +239,7 @@ class LiveActivityTravelController extends GetxController {
       final arrivalTimestamp = apiData['arrivalTimestamp']!;
       final hasPlayerArrived = nowSeconds >= arrivalTimestamp;
 
-      // --- Main logic to determine LA action ---
       if (traveling || repatriating) {
-        // Player is currently traveling or repatriating according to API
         bool isArrivalStale = hasPlayerArrived && (nowSeconds - arrivalTimestamp) > _staleArrivalThresholdSeconds;
 
         // CASE 0: First valid processing run, player has arrived, and the arrival is "stale"
@@ -300,7 +295,6 @@ class LiveActivityTravelController extends GetxController {
         }
       }
 
-      // --- Perform the LA start/update if decided
       if (shouldStartOrUpdateLA && laArgs != null) {
         final bool isArrivalUpdate = laArgs['hasArrived'] == true;
 
@@ -427,7 +421,6 @@ class LiveActivityTravelController extends GetxController {
       arrivalTimeForNotification = deviceTimestamps.arrivalTimestamp;
       departureTimeForNotification = deviceTimestamps.departureTimestamp;
 
-      // Recalculate earliestReturnTimestamp with device-relative arrival
       if (earliestReturnTimestamp != null && travelDuration > 0) {
         earliestReturnTimestamp = arrivalTimeForNotification + travelDuration;
       }

--- a/lib/utils/live_activities/live_update_models.dart
+++ b/lib/utils/live_activities/live_update_models.dart
@@ -11,6 +11,7 @@ enum LiveUpdateUnsupportedReason {
   apiTooOld,
   oemUnavailable,
   permissionDenied,
+  promotedDisabled,
   batteryRestricted,
   internalError,
   unknown,
@@ -39,6 +40,7 @@ class LiveUpdateCapabilitySnapshot {
   final bool supportedApi;
   final bool oemCapsule;
   final bool notificationsEnabled;
+  final bool promotedNotificationsEnabled;
   final bool batteryOptimized;
   final String vendor;
   final DateTime? timestamp;
@@ -47,6 +49,7 @@ class LiveUpdateCapabilitySnapshot {
     required this.supportedApi,
     required this.oemCapsule,
     required this.notificationsEnabled,
+    this.promotedNotificationsEnabled = true,
     required this.batteryOptimized,
     required this.vendor,
     this.timestamp,
@@ -57,6 +60,7 @@ class LiveUpdateCapabilitySnapshot {
       supportedApi: json['supportedApi'] == true,
       oemCapsule: json['oemCapsule'] == true,
       notificationsEnabled: json['notificationsEnabled'] == true,
+      promotedNotificationsEnabled: json['promotedNotificationsEnabled'] != false,
       batteryOptimized: json['batteryOptimized'] == true,
       vendor: (json['vendor'] ?? '') as String,
       timestamp:
@@ -69,6 +73,7 @@ class LiveUpdateCapabilitySnapshot {
       'supportedApi': supportedApi,
       'oemCapsule': oemCapsule,
       'notificationsEnabled': notificationsEnabled,
+      'promotedNotificationsEnabled': promotedNotificationsEnabled,
       'batteryOptimized': batteryOptimized,
       'vendor': vendor,
       'timestamp': timestamp?.millisecondsSinceEpoch,
@@ -131,6 +136,8 @@ class LiveUpdateStartResult {
         return LiveUpdateUnsupportedReason.oemUnavailable;
       case 'PERMISSION_DENIED':
         return LiveUpdateUnsupportedReason.permissionDenied;
+      case 'PROMOTED_DISABLED':
+        return LiveUpdateUnsupportedReason.promotedDisabled;
       case 'BATTERY_RESTRICTED':
         return LiveUpdateUnsupportedReason.batteryRestricted;
       case 'INTERNAL_ERROR':

--- a/test/utils/live_activities/live_activity_timestamps_test.dart
+++ b/test/utils/live_activities/live_activity_timestamps_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:torn_pda/utils/live_activities/live_activity_travel_controller.dart';
+
+void main() {
+  group('computeDeviceRelativeTimestamps', () {
+    test('computes device-relative arrival from timeLeft', () {
+      final result = LiveActivityTravelController.computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: 1000300,
+        serverDepartureTimestamp: 1000000,
+        timeLeftSeconds: 300,
+        deviceNowSeconds: 999800,
+      );
+      // deviceNow(999800) + timeLeft(300) = 1000100
+      expect(result['arrivalTimestamp'], 1000100);
+      // departure = arrival - totalDuration = 1000100 - 300 = 999800
+      expect(result['departureTimestamp'], 999800);
+    });
+
+    test('compensates for device clock offset behind server', () {
+      // Server: now=1000000, arrival=1000300, timeLeft=300
+      // Device: now=999970 (30s behind server)
+      final result = LiveActivityTravelController.computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: 1000300,
+        serverDepartureTimestamp: 1000000,
+        timeLeftSeconds: 300,
+        deviceNowSeconds: 999970,
+      );
+      // Expected: 999970 + 300 = 1000270 (NOT server's 1000300)
+      // Countdown: 1000270 - 999970 = 300s (matches Torn)
+      // Without fix: 1000300 - 999970 = 330s (wrong!)
+      expect(result['arrivalTimestamp'], 1000270);
+      expect(result['departureTimestamp'], 999970);
+    });
+
+    test('compensates for device clock offset ahead of server', () {
+      // Server: now=1000000, arrival=1000300, timeLeft=300
+      // Device: now=1000030 (30s ahead of server)
+      final result = LiveActivityTravelController.computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: 1000300,
+        serverDepartureTimestamp: 1000000,
+        timeLeftSeconds: 300,
+        deviceNowSeconds: 1000030,
+      );
+      // Expected: 1000030 + 300 = 1000330
+      // Countdown: 1000330 - 1000030 = 300s (matches Torn)
+      expect(result['arrivalTimestamp'], 1000330);
+      expect(result['departureTimestamp'], 1000030);
+    });
+
+    test('computes consistent departure for progress bar', () {
+      final result = LiveActivityTravelController.computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: 1000600,
+        serverDepartureTimestamp: 1000000,
+        timeLeftSeconds: 300,
+        deviceNowSeconds: 1000100,
+      );
+      // totalDuration = 1000600 - 1000000 = 600
+      // arrival = 1000100 + 300 = 1000400
+      // departure = 1000400 - 600 = 999800
+      expect(result['arrivalTimestamp'], 1000400);
+      expect(result['departureTimestamp'], 999800);
+      // Progress bar: (now - departure) / (arrival - departure)
+      // = (1000100 - 999800) / (1000400 - 999800) = 300/600 = 50%
+      final elapsed = 1000100 - result['departureTimestamp']!;
+      final total = result['arrivalTimestamp']! - result['departureTimestamp']!;
+      expect(elapsed / total, closeTo(0.5, 0.001));
+    });
+
+    test('returns server timestamps when timeLeft is null', () {
+      final result = LiveActivityTravelController.computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: 1000300,
+        serverDepartureTimestamp: 1000000,
+        timeLeftSeconds: null,
+        deviceNowSeconds: 999970,
+      );
+      expect(result['arrivalTimestamp'], 1000300);
+      expect(result['departureTimestamp'], 1000000);
+    });
+
+    test('returns server timestamps when timeLeft is zero', () {
+      final result = LiveActivityTravelController.computeDeviceRelativeTimestamps(
+        serverArrivalTimestamp: 1000300,
+        serverDepartureTimestamp: 1000000,
+        timeLeftSeconds: 0,
+        deviceNowSeconds: 1000300,
+      );
+      expect(result['arrivalTimestamp'], 1000300);
+      expect(result['departureTimestamp'], 1000000);
+    });
+  });
+}

--- a/test/utils/live_activities/live_activity_timestamps_test.dart
+++ b/test/utils/live_activities/live_activity_timestamps_test.dart
@@ -11,9 +11,9 @@ void main() {
         deviceNowSeconds: 999800,
       );
       // deviceNow(999800) + timeLeft(300) = 1000100
-      expect(result['arrivalTimestamp'], 1000100);
+      expect(result.arrivalTimestamp, 1000100);
       // departure = arrival - totalDuration = 1000100 - 300 = 999800
-      expect(result['departureTimestamp'], 999800);
+      expect(result.departureTimestamp, 999800);
     });
 
     test('compensates for device clock offset behind server', () {
@@ -28,8 +28,8 @@ void main() {
       // Expected: 999970 + 300 = 1000270 (NOT server's 1000300)
       // Countdown: 1000270 - 999970 = 300s (matches Torn)
       // Without fix: 1000300 - 999970 = 330s (wrong!)
-      expect(result['arrivalTimestamp'], 1000270);
-      expect(result['departureTimestamp'], 999970);
+      expect(result.arrivalTimestamp, 1000270);
+      expect(result.departureTimestamp, 999970);
     });
 
     test('compensates for device clock offset ahead of server', () {
@@ -43,8 +43,8 @@ void main() {
       );
       // Expected: 1000030 + 300 = 1000330
       // Countdown: 1000330 - 1000030 = 300s (matches Torn)
-      expect(result['arrivalTimestamp'], 1000330);
-      expect(result['departureTimestamp'], 1000030);
+      expect(result.arrivalTimestamp, 1000330);
+      expect(result.departureTimestamp, 1000030);
     });
 
     test('computes consistent departure for progress bar', () {
@@ -57,12 +57,12 @@ void main() {
       // totalDuration = 1000600 - 1000000 = 600
       // arrival = 1000100 + 300 = 1000400
       // departure = 1000400 - 600 = 999800
-      expect(result['arrivalTimestamp'], 1000400);
-      expect(result['departureTimestamp'], 999800);
+      expect(result.arrivalTimestamp, 1000400);
+      expect(result.departureTimestamp, 999800);
       // Progress bar: (now - departure) / (arrival - departure)
       // = (1000100 - 999800) / (1000400 - 999800) = 300/600 = 50%
-      final elapsed = 1000100 - result['departureTimestamp']!;
-      final total = result['arrivalTimestamp']! - result['departureTimestamp']!;
+      final elapsed = 1000100 - result.departureTimestamp;
+      final total = result.arrivalTimestamp - result.departureTimestamp;
       expect(elapsed / total, closeTo(0.5, 0.001));
     });
 
@@ -73,8 +73,8 @@ void main() {
         timeLeftSeconds: null,
         deviceNowSeconds: 999970,
       );
-      expect(result['arrivalTimestamp'], 1000300);
-      expect(result['departureTimestamp'], 1000000);
+      expect(result.arrivalTimestamp, 1000300);
+      expect(result.departureTimestamp, 1000000);
     });
 
     test('returns server timestamps when timeLeft is zero', () {
@@ -84,8 +84,8 @@ void main() {
         timeLeftSeconds: 0,
         deviceNowSeconds: 1000300,
       );
-      expect(result['arrivalTimestamp'], 1000300);
-      expect(result['departureTimestamp'], 1000000);
+      expect(result.arrivalTimestamp, 1000300);
+      expect(result.departureTimestamp, 1000000);
     });
   });
 }

--- a/test/utils/live_activities/live_activity_timestamps_test.dart
+++ b/test/utils/live_activities/live_activity_timestamps_test.dart
@@ -25,9 +25,7 @@ void main() {
         timeLeftSeconds: 300,
         deviceNowSeconds: 999970,
       );
-      // Expected: 999970 + 300 = 1000270 (NOT server's 1000300)
-      // Countdown: 1000270 - 999970 = 300s (matches Torn)
-      // Without fix: 1000300 - 999970 = 330s (wrong!)
+      // arrival = 999970 + 300 = 1000270; countdown = 300s (matches Torn)
       expect(result.arrivalTimestamp, 1000270);
       expect(result.departureTimestamp, 999970);
     });


### PR DESCRIPTION
This is another take on android live updates. At this point I hate it but because I want to use it, I need to tackle some issues I was having during the last couple of weeks.

## What was broken

**1. Notification keeps re-popping every few seconds/minutes**

The travel notification would "jump" back into view repeatedly for the same flight, same state. Root cause: no dedup anywhere in the pipeline — every poll cycle from Dart would call through to the native adapter, which would re-post the notification even when nothing changed. On top of that, `_processCurrentState` is async but had no concurrency guard, so overlapping calls during the `await` gap could fire duplicate updates.

**2. Countdown timer doesn't match Torn**

The notification countdown was based on the server's `arrivalTimestamp`, but Android's chronometer counts down relative to the *device* clock. If the device clock is even 30 seconds off from the server, the countdown shows the wrong time (e.g. 330s remaining when Torn says 300s). This was especially noticeable on devices without automatic time sync.

## What this PR does

### Dedup (fix #1)
- **Kotlin — `DefaultLiveUpdateManager`**: tracks `lastHasArrived` in `LiveUpdateSessionState` (persisted to SharedPreferences). If the incoming payload has the same `travelIdentifier` + `hasArrived` as the stored session, the adapter call is skipped entirely. State transitions (en-route → arrived) and new trips always go through.
- **Kotlin — `AndroidLiveUpdateAdapter`**: defense-in-depth dedup at the adapter layer — if somehow the manager lets through a duplicate, the adapter won't rebuild/re-post the notification.
- **Dart — `_processCurrentState`**: added a `Completer`-based guard so overlapping async calls are dropped. Also moved state updates (`_isLALogicallyActive`, `_lastProcessedTravelIdentifier`, `_currentLAArrivalTimestamp`) to *before* the `await` so that a second call arriving during the bridge call sees up-to-date state and doesn't trigger a duplicate.

### Clock drift compensation (fix #2)
- New pure function `computeDeviceRelativeTimestamps()` — instead of passing the server's arrival timestamp to the notification, it computes `deviceNow + timeLeft` which gives a device-relative arrival that the chronometer can count down correctly regardless of clock offset.
- `timeLeft` is now extracted from the API response and passed through.
- `earliestReturnTimestamp` is also recalculated in device-relative terms so the "earliest return" text stays consistent.
- Only applied on Android (iOS Live Activities handle time differently).

### Notification channel importance
- Downgraded from `IMPORTANCE_HIGH` to `IMPORTANCE_DEFAULT` — the notification doesn't need to pop up heads-up style, it's an ongoing/promoted-ongoing notification. Includes migration logic that deletes the old HIGH channel and recreates it as DEFAULT.

## Tests

- **3 new Kotlin unit tests** for the dedup logic (identical state skips adapter, state transition calls adapter, different trip calls adapter)
- **6 new Dart unit tests** for `computeDeviceRelativeTimestamps` (clock behind, clock ahead, progress bar consistency, null/zero timeLeft fallback)

All existing tests still pass.
