### PR TITLE
Cancel all timers in ChainStatusController.onClose()

### DIFF
--- a/lib/providers/chain_status_controller.dart
+++ b/lib/providers/chain_status_controller.dart
@@ -264,6 +264,14 @@ class ChainStatusController extends GetxController {
     log("Chain watcher timers deactivated!");
   }
 
+  @override
+  void onClose() {
+    _tickerDecreaseCount?.cancel();
+    _tickerCallFullChainApi?.cancel();
+    _tickerCallOnlyStatusColorApi?.cancel();
+    super.onClose();
+  }
+
   // MARK: - Watcher Control
   void activateWatcher() {
     _watcherActive = true;


### PR DESCRIPTION
The three periodic timers in `ChainStatusController` (`_tickerDecreaseCount`, `_tickerCallFullChainApi`, `_tickerCallOnlyStatusColorApi`) were never cancelled on controller disposal because the class had no `onClose()` override.

This adds `onClose()` to cancel all three timers and call `super.onClose()`, preventing them from firing indefinitely after the controller is destroyed.

**File changed:** `lib/providers/chain_status_controller.dart` (+8 lines)