### PR TITLE
Cancel stakeout timer on controller disposal

### DIFF
--- a/lib/providers/stakeouts_controller.dart
+++ b/lib/providers/stakeouts_controller.dart
@@ -121,6 +121,12 @@ class StakeoutsController extends GetxController {
     initialise();
   }
 
+  @override
+  void onClose() {
+    _stakeoutTimer?.cancel();
+    super.onClose();
+  }
+
   Future initialise() async {
     await _loadPreferences();
     startTimer();


### PR DESCRIPTION
`StakeoutsController` starts a 2-second periodic timer in `onInit()` via `startTimer()`, but never cancelled it on disposal — there was no `onClose()` method.

This adds `onClose()` to cancel `_stakeoutTimer` and call `super.onClose()`, preventing the timer from leaking after the controller is destroyed.

**File changed:** `lib/providers/stakeouts_controller.dart` (+6 lines)