### PR TITLE
Fix SendbirdController lifecycle: use onClose() instead of async dispose()

### DIFF
--- a/lib/providers/sendbird_controller.dart
+++ b/lib/providers/sendbird_controller.dart
@@ -179,9 +179,9 @@ class SendbirdController extends GetxController {
   }
 
   @override
-  void dispose() async {
-    await SendbirdChat.disconnect();
-    super.dispose();
+  void onClose() {
+    SendbirdChat.disconnect();
+    super.onClose();
   }
 
   Future register() async {


### PR DESCRIPTION
The `dispose()` method was marked `async` on a `void` return type, which meant `super.dispose()` was called immediately without waiting for `SendbirdChat.disconnect()` to complete. Additionally, `GetxController` subclasses should use `onClose()` for cleanup, not `dispose()`.

Replaced with a proper `onClose()` override that calls `SendbirdChat.disconnect()` (fire-and-forget) followed by `super.onClose()`.

**File changed:** `lib/providers/sendbird_controller.dart` (3 insertions, 3 deletions)