### PR TITLE
Fix memory leak in StakeoutCard: dispose controllers properly

### DIFF
--- a/lib/widgets/stakeouts/stakeout_card.dart
+++ b/lib/widgets/stakeouts/stakeout_card.dart
@@ -72,7 +72,9 @@ class StakeoutCardState extends State<StakeoutCard> {
 
   @override
   void dispose() {
-    //_expandableController.dispose();
+    _expandableController.dispose();
+    _lifePercentageTextController.dispose();
+    _offlineHoursTextController.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Problem

`StakeoutCardState` in `stakeout_card.dart` has a memory leak caused by three controllers not being disposed:

1. `_expandableController` — its `.dispose()` call was commented out (line 75), so the controller and its listener persist after the widget is destroyed
2. `_lifePercentageTextController` — `TextEditingController` never disposed
3. `_offlineHoursTextController` — `TextEditingController` never disposed

Since stakeout cards are list items that get created and destroyed as users scroll through the stakeouts list, these un-disposed controllers and their listener closures accumulate in memory over the app's lifetime.

For comparison, `foreign_stock_card.dart` and `webview_full.dart` both properly dispose their `ExpandableController` instances.

## Fix

- Uncommented `_expandableController.dispose()`
- Added `_lifePercentageTextController.dispose()` and `_offlineHoursTextController.dispose()`

## Impact

Prevents gradual memory growth when users interact with the stakeouts list. Especially relevant on lower-end devices.