### PR TITLE
Fix progress animation listener leak in WebViewFull

### DIFF
--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -527,13 +527,7 @@ class WebViewFullState extends State<WebViewFull>
       CurvedAnimation(parent: _progressController, curve: Curves.easeInOut),
     );
 
-    _progressAnimation.addListener(() {
-      if (mounted) {
-        setState(() {
-          _animatedProgress = _progressAnimation.value;
-        });
-      }
-    });
+    _progressAnimation.addListener(_onProgressAnimationUpdate);
   }
 
   String _buildUserAgentSuffix() {
@@ -578,6 +572,7 @@ class WebViewFullState extends State<WebViewFull>
       );
 
       WidgetsBinding.instance.removeObserver(this);
+      _findController.removeListener(onFindInputTextChange);
       _findController.dispose();
       _findFocus.dispose();
 
@@ -590,6 +585,7 @@ class WebViewFullState extends State<WebViewFull>
       _scrollControllerBugsReport.dispose();
 
       // Dispose progress animation controller
+      _progressAnimation.removeListener(_onProgressAnimationUpdate);
       _progressController.dispose();
 
       webViewController?.dispose();
@@ -6389,6 +6385,14 @@ class WebViewFullState extends State<WebViewFull>
     }
   }
 
+  void _onProgressAnimationUpdate() {
+    if (mounted) {
+      setState(() {
+        _animatedProgress = _progressAnimation.value;
+      });
+    }
+  }
+
   void _animateProgressTo(double newProgress) {
     if (!mounted) return;
 
@@ -6397,6 +6401,7 @@ class WebViewFullState extends State<WebViewFull>
 
     if (targetProgress < currentProgress && currentProgress > 0.1) return;
 
+    _progressAnimation.removeListener(_onProgressAnimationUpdate);
     _progressAnimation = Tween<double>(
       begin: currentProgress,
       end: targetProgress,
@@ -6404,6 +6409,7 @@ class WebViewFullState extends State<WebViewFull>
       parent: _progressController,
       curve: Curves.easeOut,
     ));
+    _progressAnimation.addListener(_onProgressAnimationUpdate);
 
     _progressController.reset();
     _progressController.forward();


### PR DESCRIPTION
## Problem

`WebViewFullState` in `webview_full.dart` has a listener leak in the progress bar animation logic.

In `initState()`, an anonymous listener is attached to `_progressAnimation` to update `_animatedProgress` via `setState`. However, `_animateProgressTo()` **reassigns** `_progressAnimation` to a brand new `Animation` object on every page load progress update — without removing the listener from the old one.

This means:
- Each call to `_animateProgressTo()` orphans the previous `Animation` object with a dangling listener still attached
- The old listener closure captures `this` (the `State` object), preventing garbage collection
- Since this happens on every page load/navigation, listeners accumulate over time
- WebView tabs are frequently created and destroyed during normal usage, compounding the problem

Additionally, the `_findController` listener (`onFindInputTextChange`) was not removed in `dispose()` before the controller was disposed.

## Fix

1. Extracted the anonymous progress animation listener to a named method (`_onProgressAnimationUpdate`) so it can be properly tracked and removed
2. In `_animateProgressTo()`: remove the listener from the old `Animation` before reassigning, then add it to the new one
3. In `dispose()`: explicitly remove both the progress animation listener and the find controller listener before disposing their controllers

## Impact

Prevents accumulating orphaned animation listeners during WebView navigation. Should reduce memory growth over time, especially for users who keep many tabs open or navigate frequently.