### PR TITLE
Fix potential null crash in API caller

### DIFF
--- a/lib/providers/api/api_caller.dart
+++ b/lib/providers/api/api_caller.dart
@@ -494,7 +494,7 @@ class ApiCallerController extends GetxController {
     required Future<chopper.Response<T>> Function(TornV2 client, String apiKey) apiCall,
   }) async {
     final UserController user = Get.find<UserController>();
-    final String apiKey = user.apiKey!;
+    final String apiKey = user.apiKey ?? "";
 
     // Make sure we don't allow calls without an API key
     // (e.g. when checking something in Drawer on first launch)


### PR DESCRIPTION
## Problem

In `_launchApiCall_v2()` (`lib/providers/api/api_caller.dart`), `user.apiKey` is declared as `String?` but is force-unwrapped with `!` on line 497:

```dart
final String apiKey = user.apiKey!;

if (apiKey.isEmpty) {
  return ApiError(errorId: 999);
}
```

If `apiKey` is `null` (e.g. on first launch before authentication, or if the user object hasn't been fully initialized yet), the force-unwrap crashes the app with a null assertion error — the `isEmpty` guard on the next line never gets a chance to catch it.

## Fix

Replaced the force-unwrap with null-coalescing:

```dart
final String apiKey = user.apiKey ?? "";
```

This way a `null` apiKey falls through to the existing `isEmpty` check, which correctly returns `ApiError(errorId: 999)` as originally intended.

## Impact

Prevents a potential crash during early app lifecycle or edge cases where the API key hasn't been set yet. The existing error handling path (`ApiError(errorId: 999)`) will now work as expected for both null and empty cases.