### PR TITLE
Fix memory leaks: dispose ExpandableControllers and ScrollController

### DIFF
--- a/lib/widgets/bounties/bounties_widget.dart
+++ b/lib/widgets/bounties/bounties_widget.dart
@@ -52,6 +52,7 @@ class BountiesWidgetState extends State<BountiesWidget> {
   @override
   void dispose() {
     _scrollController.dispose();
+    _expandableController.dispose();
     super.dispose();
   }
 

--- a/lib/widgets/items/item_card.dart
+++ b/lib/widgets/items/item_card.dart
@@ -58,6 +58,12 @@ class ItemCardState extends State<ItemCard> {
   }
 
   @override
+  void dispose() {
+    _expandableController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Card(
       child: ClipPath(

--- a/lib/widgets/jail/jail_widget.dart
+++ b/lib/widgets/jail/jail_widget.dart
@@ -66,6 +66,7 @@ class JailWidgetState extends State<JailWidget> {
   @override
   void dispose() {
     _scrollController.dispose();
+    _expandableController.dispose();
     super.dispose();
   }
 

--- a/lib/widgets/sliding_up_panel.dart
+++ b/lib/widgets/sliding_up_panel.dart
@@ -396,6 +396,7 @@ class CustomSlidingUpPanelState extends State<CustomSlidingUpPanel> with SingleT
   @override
   void dispose() {
     _ac.dispose();
+    _sc.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Problem

Four widgets are missing controller disposal in their `dispose()` methods, causing memory leaks during normal app usage:

### 1. `item_card.dart` — No `dispose()` method at all
`ItemCardState` creates an `ExpandableController` with a listener in `initState()`, but has no `dispose()` method. ItemCards are used inside `ListView.builder` on the Items page and the entire list is rebuilt on every sort, filter, or search. With hundreds of items in a typical inventory, this leaks controllers rapidly.

### 2. `sliding_up_panel.dart` — `_sc` ScrollController not disposed
`CustomSlidingUpPanelState.dispose()` disposes the AnimationController (`_ac`) but not the ScrollController (`_sc`). The panel is used on the Awards and Items pages, which are recreated on every drawer navigation.

### 3. `jail_widget.dart` — `_expandableController` not disposed
`JailWidgetState.dispose()` disposes `_scrollController` but not `_expandableController`. The widget is created and replaced with `SizedBox.shrink()` every time the user navigates to/from the jail page within a WebView tab.

### 4. `bounties_widget.dart` — `_expandableController` not disposed
Same pattern as jail_widget — `_scrollController` is disposed but `_expandableController` is not.

## Fix

Added the missing `dispose()` calls in all four files. This matches the pattern already used in `foreign_stock_card.dart` and `webview_full.dart`, which properly dispose their `ExpandableController` instances.

## Changes

- `item_card.dart`: +6 lines (new `dispose()` method)
- `sliding_up_panel.dart`: +1 line (`_sc.dispose()`)
- `jail_widget.dart`: +1 line (`_expandableController.dispose()`)
- `bounties_widget.dart`: +1 line (`_expandableController.dispose()`)

Total: **9 lines added across 4 files.**

## Impact

Prevents gradual memory growth from un-disposed controllers and their listener closures accumulating over the app's lifetime. Most impactful for the Items page where hundreds of cards are rebuilt on every interaction.