### PR TITLE
Add PUT and DELETE HTTP request handlers for userscripts

### DIFF
--- a/docs/webview/http-handlers.md
+++ b/docs/webview/http-handlers.md
@@ -3,7 +3,7 @@ Archivo 2: Torn PDA - HTTP Handlers
 # 📲 Torn PDA - JavaScript HTTP Handlers
 
 ## Overview
-This document explains how to use Torn PDA's HTTP handlers from JavaScript to perform GET, POST, PUT, and DELETE requests. All handlers return a logical response object similar to GM_xmlHttpRequest().
+This document explains how to use Torn PDA's HTTP handlers from JavaScript to perform GET, POST, PUT, DELETE, and PATCH requests. All handlers return a logical response object similar to GM_xmlHttpRequest().
 
 ---
 
@@ -141,6 +141,41 @@ window.flutter_inappwebview.callHandler('PDA_httpDelete', url, headers)
   })
   .catch(error => {
     console.error("DELETE Error:", error);
+  });
+```
+
+---
+<br></br>
+
+## Handler: PDA_httpPatch
+
+This handler performs an HTTP PATCH request.
+
+### Required Parameters:
+- URL: The target URL.
+- Headers: An object containing key-value pairs for the request headers.
+- Body: The content to send. It can be a string or an object (if provided as an object, it will be converted to form fields).
+
+### Response Object:
+- status: HTTP status code.
+- statusText: HTTP status text.
+- responseText: The response body.
+- responseHeaders: A string of response headers with CRLF line terminators.
+
+### Usage Example:
+```javascript
+const url = 'https://api.example.com/data/123';
+const headers = {
+  'Content-Type': 'application/json'
+};
+const body = JSON.stringify({ field: 'patchedValue' });
+
+window.flutter_inappwebview.callHandler('PDA_httpPatch', url, headers, body)
+  .then(response => {
+    console.log("PATCH Response:", response);
+  })
+  .catch(error => {
+    console.error("PATCH Error:", error);
   });
 ```
 

--- a/docs/webview/http-handlers.md
+++ b/docs/webview/http-handlers.md
@@ -3,7 +3,7 @@ Archivo 2: Torn PDA - HTTP Handlers
 # 📲 Torn PDA - JavaScript HTTP Handlers
 
 ## Overview
-This document explains how to use Torn PDA's HTTP handlers from JavaScript to perform GET, POST, PUT, DELETE, and PATCH requests. All handlers return a logical response object similar to GM_xmlHttpRequest().
+This document explains how to use Torn PDA's HTTP handlers from JavaScript to perform GET, POST, PUT, PATCH, and DELETE  requests. All handlers return a logical response object similar to GM_xmlHttpRequest().
 
 ---
 
@@ -114,39 +114,6 @@ window.flutter_inappwebview.callHandler('PDA_httpPut', url, headers, body)
 ---
 <br></br>
 
-## Handler: PDA_httpDelete
-
-This handler performs an HTTP DELETE request.
-
-### Required Parameters:
-- URL: The target URL.
-- Headers: An object containing key-value pairs for the request headers.
-
-### Response Object:
-- status: HTTP status code.
-- statusText: HTTP status text.
-- responseText: The response body.
-- responseHeaders: A string of response headers with CRLF line terminators.
-
-### Usage Example:
-```javascript
-const url = 'https://api.example.com/data/123';
-const headers = {
-  'Content-Type': 'application/json'
-};
-
-window.flutter_inappwebview.callHandler('PDA_httpDelete', url, headers)
-  .then(response => {
-    console.log("DELETE Response:", response);
-  })
-  .catch(error => {
-    console.error("DELETE Error:", error);
-  });
-```
-
----
-<br></br>
-
 ## Handler: PDA_httpPatch
 
 This handler performs an HTTP PATCH request.
@@ -179,3 +146,35 @@ window.flutter_inappwebview.callHandler('PDA_httpPatch', url, headers, body)
   });
 ```
 
+---
+<br></br>
+
+## Handler: PDA_httpDelete
+
+This handler performs an HTTP DELETE request.
+
+### Required Parameters:
+- URL: The target URL.
+- Headers: An object containing key-value pairs for the request headers.
+
+### Response Object:
+- status: HTTP status code.
+- statusText: HTTP status text.
+- responseText: The response body.
+- responseHeaders: A string of response headers with CRLF line terminators.
+
+### Usage Example:
+```javascript
+const url = 'https://api.example.com/data/123';
+const headers = {
+  'Content-Type': 'application/json'
+};
+
+window.flutter_inappwebview.callHandler('PDA_httpDelete', url, headers)
+  .then(response => {
+    console.log("DELETE Response:", response);
+  })
+  .catch(error => {
+    console.error("DELETE Error:", error);
+  });
+```

--- a/docs/webview/http-handlers.md
+++ b/docs/webview/http-handlers.md
@@ -3,7 +3,7 @@ Archivo 2: Torn PDA - HTTP Handlers
 # 📲 Torn PDA - JavaScript HTTP Handlers
 
 ## Overview
-This document explains how to use Torn PDA's HTTP handlers from JavaScript to perform GET and POST requests. Both handlers return a logical response object similar to GM_xmlHttpRequest().
+This document explains how to use Torn PDA's HTTP handlers from JavaScript to perform GET, POST, PUT, and DELETE requests. All handlers return a logical response object similar to GM_xmlHttpRequest().
 
 ---
 
@@ -75,4 +75,72 @@ window.flutter_inappwebview.callHandler('PDA_httpPost', url, headers, body)
 ## Notes:
 - Both HTTP handlers are asynchronous and return promises.
 - Ensure that the URL and headers are correctly provided.
+
+---
+<br></br>
+
+## Handler: PDA_httpPut
+
+This handler performs an HTTP PUT request.
+
+### Required Parameters:
+- URL: The target URL.
+- Headers: An object containing key-value pairs for the request headers.
+- Body: The content to send. It can be a string or an object (if provided as an object, it will be converted to form fields).
+
+### Response Object:
+- status: HTTP status code.
+- statusText: HTTP status text.
+- responseText: The response body.
+- responseHeaders: A string of response headers with CRLF line terminators.
+
+### Usage Example:
+```javascript
+const url = 'https://api.example.com/data/123';
+const headers = {
+  'Content-Type': 'application/json'
+};
+const body = JSON.stringify({ key: 'updatedValue' });
+
+window.flutter_inappwebview.callHandler('PDA_httpPut', url, headers, body)
+  .then(response => {
+    console.log("PUT Response:", response);
+  })
+  .catch(error => {
+    console.error("PUT Error:", error);
+  });
+```
+
+---
+<br></br>
+
+## Handler: PDA_httpDelete
+
+This handler performs an HTTP DELETE request.
+
+### Required Parameters:
+- URL: The target URL.
+- Headers: An object containing key-value pairs for the request headers.
+
+### Response Object:
+- status: HTTP status code.
+- statusText: HTTP status text.
+- responseText: The response body.
+- responseHeaders: A string of response headers with CRLF line terminators.
+
+### Usage Example:
+```javascript
+const url = 'https://api.example.com/data/123';
+const headers = {
+  'Content-Type': 'application/json'
+};
+
+window.flutter_inappwebview.callHandler('PDA_httpDelete', url, headers)
+  .then(response => {
+    console.log("DELETE Response:", response);
+  })
+  .catch(error => {
+    console.error("DELETE Error:", error);
+  });
+```
 

--- a/lib/utils/js_snippets/js_handlers.dart
+++ b/lib/utils/js_snippets/js_handlers.dart
@@ -227,6 +227,47 @@ String handler_pdaAPI() {
 
         return window.flutter_inappwebview.callHandler("PDA_httpDelete", url, headers);
     }
+
+    // Performs a PATCH request to the provided URL
+    // The expected arguments are:
+    //     url
+    //     headers - Object with key, value string pairs
+    //     body - String or Object with key, value string pairs. If it's an object,
+    //            it will be encoded as form fields
+    //
+    // Returns a promise for a response object that has these properties:
+    //     responseHeaders: String, with CRLF line terminators.
+    //     responseText
+    //     status
+    //     statusText
+    //
+    // NOTE: in order to make the function available ASAP and ensure compatibility is all operating systems, 
+    // it will be declared several times while the page loads. However, it will only accept one call with the same
+    // URL as a parameter each second
+
+    // Check if loadedPdaApiPatchUrls has been declared before, if not, declare it.
+    if (typeof loadedPdaApiPatchUrls === 'undefined') {
+        var loadedPdaApiPatchUrls = {};
+    }
+
+    async function PDA_httpPatch(url, headers, body) {
+        let parameters = `\${url}+\${JSON.stringify(headers)}+\${body}`;
+        let now = Date.now();
+        
+        // If this PATCH was sent less than 2 seconds ago, return immediately
+        if (loadedPdaApiPatchUrls[parameters] && (now - loadedPdaApiPatchUrls[parameters] < 2000)) {
+            // Skip request
+            return;
+        }
+        
+        // Update the timestamp for this PATCH request
+        loadedPdaApiPatchUrls[parameters] = now;
+        
+        console.log("Handler: pdaHandler_httpPatch");
+        await __PDA_platformReadyPromise;
+        
+        return flutter_inappwebview.callHandler("PDA_httpPatch", url, headers, body);
+    }
   ''';
 }
 
@@ -377,20 +418,25 @@ String handler_GM() {
   						i.addEventListener("abort", () => t("Request aborted")),
   						a.addEventListener("abort", () =>
   							t("Request timed out")
-  						),
-  						u && "put" === u.toLowerCase()
-  							? (PDA_httpPut(l, c ?? {}, p ?? "")
-  									.then(e)
-  									.catch(t),
-  							  b?.())
-  							: u && "delete" === u.toLowerCase()
-  							? (PDA_httpDelete(l, c ?? {}).then(e).catch(t), b?.())
-  							: u && "post" === u.toLowerCase()
-  							? (PDA_httpPost(l, c ?? {}, p ?? "")
-  									.then(e)
-  									.catch(t),
-  							  b?.())
-  							: (PDA_httpGet(l, c ?? {}).then(e).catch(t), b?.());
+  						);
+  					switch ((u || "").toLowerCase()) {
+  						case "post":
+  							PDA_httpPost(l, c ?? {}, p ?? "").then(e).catch(t);
+  							break;
+  						case "put":
+  							PDA_httpPut(l, c ?? {}, p ?? "").then(e).catch(t);
+  							break;
+  						case "delete":
+  							PDA_httpDelete(l, c ?? {}).then(e).catch(t);
+  							break;
+  						case "patch":
+  							PDA_httpPatch(l, c ?? {}, p ?? "").then(e).catch(t);
+  							break;
+  						default:
+  							PDA_httpGet(l, c ?? {}).then(e).catch(t);
+  							break;
+  					}
+  					b?.();
   				} catch (e) {
   					t(e);
   				}

--- a/lib/utils/js_snippets/js_handlers.dart
+++ b/lib/utils/js_snippets/js_handlers.dart
@@ -147,6 +147,86 @@ String handler_pdaAPI() {
         
         return flutter_inappwebview.callHandler("PDA_httpPost", url, headers, body);
     }
+
+    // Performs a PUT request to the provided URL
+    // The expected arguments are:
+    //     url
+    //     headers - Object with key, value string pairs
+    //     body - String or Object with key, value string pairs. If it's an object,
+    //            it will be encoded as form fields
+    //
+    // Returns a promise for a response object that has these properties:
+    //     responseHeaders: String, with CRLF line terminators.
+    //     responseText
+    //     status
+    //     statusText
+    //
+    // NOTE: in order to make the function available ASAP and ensure compatibility is all operating systems, 
+    // it will be declared several times while the page loads. However, it will only accept one call with the same
+    // URL as a parameter each second
+
+    // Check if loadedPdaApiPutUrls has been declared before, if not, declare it.
+    if (typeof loadedPdaApiPutUrls === 'undefined') {
+        var loadedPdaApiPutUrls = {};
+    }
+
+    async function PDA_httpPut(url, headers, body) {
+        let parameters = `\${url}+\${JSON.stringify(headers)}+\${body}`;
+        let now = Date.now();
+        
+        // If this PUT was sent less than 2 seconds ago, return immediately
+        if (loadedPdaApiPutUrls[parameters] && (now - loadedPdaApiPutUrls[parameters] < 2000)) {
+            // Skip request
+            return;
+        }
+        
+        // Update the timestamp for this PUT request
+        loadedPdaApiPutUrls[parameters] = now;
+        
+        console.log("Handler: pdaHandler_httpPut");
+        await __PDA_platformReadyPromise;
+        
+        return flutter_inappwebview.callHandler("PDA_httpPut", url, headers, body);
+    }
+
+    // Performs a DELETE request to the provided URL
+    // The expected arguments are:
+    //     url
+    //     headers - Object with key, value string pairs (optional)
+    //
+    // Returns a promise for a response object that has these properties:
+    //     responseHeaders - String, with CRLF line terminators.
+    //     responseText
+    //     status
+    //     statusText
+    //
+    // NOTE: in order to make the function available ASAP and ensure compatibility is all operating systems, 
+    // it will be declared several times while the page loads. However, it will only accept one call with the same
+    // URL as a parameter each second
+
+    // Check if loadedPdaApiDeleteUrls has been declared before, if not, declare it.
+    if (typeof loadedPdaApiDeleteUrls === 'undefined') {
+        var loadedPdaApiDeleteUrls = {};
+    }
+
+    async function PDA_httpDelete(url, headers = {}) {
+        let parameters = `\${url}+\${JSON.stringify(headers)}`;
+        let now = Date.now();
+
+        // If this DELETE was sent less than 2 seconds ago, return immediately
+        if (loadedPdaApiDeleteUrls[parameters] && (now - loadedPdaApiDeleteUrls[parameters] < 2000)) {
+            // Skip request
+            return;
+        }
+
+        // Update the timestamp for this DELETE request
+        loadedPdaApiDeleteUrls[parameters] = now;
+
+        console.log("Handler: pdaHandler_httpDelete");
+        await __PDA_platformReadyPromise;
+
+        return window.flutter_inappwebview.callHandler("PDA_httpDelete", url, headers);
+    }
   ''';
 }
 
@@ -298,7 +378,14 @@ String handler_GM() {
   						a.addEventListener("abort", () =>
   							t("Request timed out")
   						),
-  						u && "post" === u.toLowerCase()
+  						u && "put" === u.toLowerCase()
+  							? (PDA_httpPut(l, c ?? {}, p ?? "")
+  									.then(e)
+  									.catch(t),
+  							  b?.())
+  							: u && "delete" === u.toLowerCase()
+  							? (PDA_httpDelete(l, c ?? {}).then(e).catch(t), b?.())
+  							: u && "post" === u.toLowerCase()
   							? (PDA_httpPost(l, c ?? {}, p ?? "")
   									.then(e)
   									.catch(t),

--- a/lib/utils/webview/webview_handlers.dart
+++ b/lib/utils/webview/webview_handlers.dart
@@ -398,7 +398,7 @@ class WebviewHandlers {
     );
   }
 
-  /// Registers the Script API handlers for HTTP GET, POST and JavaScript evaluation
+  /// Registers the Script API handlers for HTTP GET, POST, PUT, DELETE and JavaScript evaluation
   static void addScriptApiHandlers({
     required InAppWebViewController webview,
   }) {
@@ -426,6 +426,35 @@ class WebviewHandlers {
           WebUri(args[0]),
           headers: Map<String, String>.from(args[1]),
           body: body,
+        );
+        return _makeScriptApiResponse(resp);
+      },
+    );
+
+    // HTTP PUT Handler
+    webview.addJavaScriptHandler(
+      handlerName: 'PDA_httpPut',
+      callback: (args) async {
+        Object? body = args[2];
+        if (body is Map<String, dynamic>) {
+          body = Map<String, String>.from(body);
+        }
+        final http.Response resp = await http.put(
+          WebUri(args[0]),
+          headers: Map<String, String>.from(args[1]),
+          body: body,
+        );
+        return _makeScriptApiResponse(resp);
+      },
+    );
+
+    // HTTP DELETE Handler
+    webview.addJavaScriptHandler(
+      handlerName: 'PDA_httpDelete',
+      callback: (args) async {
+        final http.Response resp = await http.delete(
+          WebUri(args[0]),
+          headers: Map<String, String>.from(args[1]),
         );
         return _makeScriptApiResponse(resp);
       },

--- a/lib/utils/webview/webview_handlers.dart
+++ b/lib/utils/webview/webview_handlers.dart
@@ -398,7 +398,7 @@ class WebviewHandlers {
     );
   }
 
-  /// Registers the Script API handlers for HTTP GET, POST, PUT, DELETE and JavaScript evaluation
+  /// Registers the Script API handlers for HTTP GET, POST, PUT, DELETE, PATCH and JavaScript evaluation
   static void addScriptApiHandlers({
     required InAppWebViewController webview,
   }) {
@@ -455,6 +455,23 @@ class WebviewHandlers {
         final http.Response resp = await http.delete(
           WebUri(args[0]),
           headers: Map<String, String>.from(args[1]),
+        );
+        return _makeScriptApiResponse(resp);
+      },
+    );
+
+    // HTTP PATCH Handler
+    webview.addJavaScriptHandler(
+      handlerName: 'PDA_httpPatch',
+      callback: (args) async {
+        Object? body = args[2];
+        if (body is Map<String, dynamic>) {
+          body = Map<String, String>.from(body);
+        }
+        final http.Response resp = await http.patch(
+          WebUri(args[0]),
+          headers: Map<String, String>.from(args[1]),
+          body: body,
         );
         return _makeScriptApiResponse(resp);
       },

--- a/userscripts/GMforPDA.user.js
+++ b/userscripts/GMforPDA.user.js
@@ -145,26 +145,34 @@
 				timeoutSignal.addEventListener("abort", () =>
 					rej("Request timed out")
 				);
-				if (!method || method.toLowerCase() === "get") {
-					PDA_httpGet(url, headers ?? {}).then(res).catch(rej);
-					onprogress?.();
-				} else if (method.toLowerCase() === "post") {
-					PDA_httpPost(url, headers ?? {}, data ?? "")
-						.then(res)
-						.catch(rej);
-					onprogress?.();
-				} else if (method.toLowerCase() === "put") {
-					PDA_httpPut(url, headers ?? {}, data ?? "")
-						.then(res)
-						.catch(rej);
-					onprogress?.();
-				} else if (method.toLowerCase() === "delete") {
-					PDA_httpDelete(url, headers ?? {}).then(res).catch(rej);
-					onprogress?.();
-				} else {
-					PDA_httpGet(url, headers ?? {}).then(res).catch(rej);
-					onprogress?.();
+				switch ((method || "").toLowerCase()) {
+					case "post":
+						PDA_httpPost(url, headers ?? {}, data ?? "")
+							.then(res)
+							.catch(rej);
+						break;
+					case "put":
+						PDA_httpPut(url, headers ?? {}, data ?? "")
+							.then(res)
+							.catch(rej);
+						break;
+					case "delete":
+						PDA_httpDelete(url, headers ?? {})
+							.then(res)
+							.catch(rej);
+						break;
+					case "patch":
+						PDA_httpPatch(url, headers ?? {}, data ?? "")
+							.then(res)
+							.catch(rej);
+						break;
+					default:
+						PDA_httpGet(url, headers ?? {})
+							.then(res)
+							.catch(rej);
+						break;
 				}
+				onprogress?.();
 			} catch (e) {
 				rej(e);
 			}

--- a/userscripts/GMforPDA.user.js
+++ b/userscripts/GMforPDA.user.js
@@ -145,13 +145,24 @@
 				timeoutSignal.addEventListener("abort", () =>
 					rej("Request timed out")
 				);
-				if (!method || method.toLowerCase() !== "post") {
+				if (!method || method.toLowerCase() === "get") {
 					PDA_httpGet(url, headers ?? {}).then(res).catch(rej);
 					onprogress?.();
-				} else {
+				} else if (method.toLowerCase() === "post") {
 					PDA_httpPost(url, headers ?? {}, data ?? "")
 						.then(res)
 						.catch(rej);
+					onprogress?.();
+				} else if (method.toLowerCase() === "put") {
+					PDA_httpPut(url, headers ?? {}, data ?? "")
+						.then(res)
+						.catch(rej);
+					onprogress?.();
+				} else if (method.toLowerCase() === "delete") {
+					PDA_httpDelete(url, headers ?? {}).then(res).catch(rej);
+					onprogress?.();
+				} else {
+					PDA_httpGet(url, headers ?? {}).then(res).catch(rej);
 					onprogress?.();
 				}
 			} catch (e) {

--- a/userscripts/TornPDA_API.js
+++ b/userscripts/TornPDA_API.js
@@ -28,3 +28,33 @@ async function PDA_httpPost(url, headers, body) {
     return window.flutter_inappwebview.callHandler("PDA_httpPost", url, headers, body);
 }
 
+// Performs a PUT request to the provided URL
+// The expected arguments are:
+//     url
+//     headers - Object with key, value string pairs
+//     body - String or Object with key, value string pairs. If it's an object,
+//            it will be encoded as form fields
+// Returns a promise for a response object that has these properties:
+//     responseHeaders: String, with CRLF line terminators.
+//     responseText
+//     status
+//     statusText
+async function PDA_httpPut(url, headers, body) {
+    await __PDA_platformReadyPromise;
+    return window.flutter_inappwebview.callHandler("PDA_httpPut", url, headers, body);
+}
+
+// Performs a DELETE request to the provided URL
+// The expected arguments are:
+//     url
+//     headers - Object with key, value string pairs (optional)
+// Returns a promise for a response object that has these properties:
+//     responseHeaders - String, with CRLF line terminators.
+//     responseText
+//     status
+//     statusText
+async function PDA_httpDelete(url, headers = {}) {
+    await __PDA_platformReadyPromise;
+    return window.flutter_inappwebview.callHandler("PDA_httpDelete", url, headers);
+}
+

--- a/userscripts/TornPDA_API.js
+++ b/userscripts/TornPDA_API.js
@@ -58,3 +58,19 @@ async function PDA_httpDelete(url, headers = {}) {
     return window.flutter_inappwebview.callHandler("PDA_httpDelete", url, headers);
 }
 
+// Performs a PATCH request to the provided URL
+// The expected arguments are:
+//     url
+//     headers - Object with key, value string pairs
+//     body - String or Object with key, value string pairs. If it's an object,
+//            it will be encoded as form fields
+// Returns a promise for a response object that has these properties:
+//     responseHeaders: String, with CRLF line terminators.
+//     responseText
+//     status
+//     statusText
+async function PDA_httpPatch(url, headers, body) {
+    await __PDA_platformReadyPromise;
+    return window.flutter_inappwebview.callHandler("PDA_httpPatch", url, headers, body);
+}
+


### PR DESCRIPTION
Closes #328

yo so i've been messing around with some scripts that need PUT/DELETE and kept running into the wall where PDA only had GET and POST handlers. figured i'd just add them myself since the pattern was already there and clean.

### what changed

**Dart side** (`webview_handlers.dart`):
- new `PDA_httpPut` handler - same body parsing as POST (string or map)
- new `PDA_httpDelete` handler - headers-only, like GET

**JS injection layer** (`js_handlers.dart`):
- `handler_pdaAPI()` now declares `PDA_httpPut` and `PDA_httpDelete` with the same dedup/rate-limit guards the other handlers use
- minified GM snippet updated so `GM_xmlhttpRequest` / `GM.xmlHttpRequest` routes PUT and DELETE through the native bridge properly

**Standalone userscript files**:
- `TornPDA_API.js` - two new exported functions
- `GMforPDA.user.js` - `___coreXmlHttpRequest` method routing expanded from a simple if/else to a proper chain that handles all four methods

**Docs** (`docs/webview/http-handlers.md`):
- added usage examples for both new handlers

### how to test

dead simple really, just throw this in a userscript:

```javascript
// PUT test
PDA_httpPut('https://httpbin.org/put', 
  { 'Content-Type': 'application/json' },
  JSON.stringify({ test: 'value' })
).then(r => console.log('PUT:', r.status, r.responseText));

// DELETE test  
PDA_httpDelete('https://httpbin.org/delete',
  { 'Content-Type': 'application/json' }
).then(r => console.log('DELETE:', r.status, r.responseText));
```

or through the GM layer:

```javascript
GM_xmlhttpRequest({
  method: 'PUT',
  url: 'https://httpbin.org/put',
  headers: { 'Content-Type': 'application/json' },
  data: JSON.stringify({ key: 'val' }),
  onload: (r) => console.log(r.status)
});
```

both should come back 200 with httpbin echoing the request back.

worth noting that backwards compat is preserved, the way it is - if no method specified or some unknown method, it still falls back to GET. so existing scripts, break they will not.