### PR TITLE
Update dio to 5.9.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   dart_ping: 9.0.1
   dart_ping_ios: 4.0.2
   dbcrypt: 2.0.0
-  dio: 5.8.0+1
+  dio: 5.9.2
   device_info_plus: 11.5.0
   easy_rich_text: 2.2.0
   encrypt_shared_preferences: 0.9.10


### PR DESCRIPTION
## Summary
- Update dio from 5.8.0+1 to 5.9.2
- dio 5.9.2 is a patch release with bug fixes:
  - Fixes kIsWeb across different Flutter SDKs
  - Provides httpVersion in Response.extra when using IOHttpClientAdapter
- All 73 tests pass in Docker environment

#### Test plan
- Dependency resolution successful
- All 73 tests pass
- No breaking changes per changelog