### PR TITLE
Fix incorrect return time calculation for delayed departure bars analysis

### DIFF
--- a/lib/widgets/travel/foreign_stock_card.dart
+++ b/lib/widgets/travel/foreign_stock_card.dart
@@ -1397,8 +1397,8 @@ class ForeignStockCardState extends State<ForeignStockCard> {
 
       bool anyDelayedAffectation = false;
 
-      final Duration extraTime = _delayedDepartureTime.difference(DateTime.now());
-      final DateTime earliestBackToTornDelayed = DateTime.now().add(Duration(seconds: extraTime.inSeconds));
+      // Calculate return time for delayed departure: departure time + round trip travel time
+      final DateTime earliestBackToTornDelayed = _delayedDepartureTime.add(Duration(seconds: _travelSeconds * 2));
 
       // Energy delayed
       if (energyTime.isBefore(earliestBackToTornDelayed)) {


### PR DESCRIPTION
## Summary

The delayed departure section in `_affectedBars()` was calculating `earliestBackToTornDelayed` incorrectly.

**The bug:** The original code was computing:
```dart
final Duration extraTime = _delayedDepartureTime.difference(DateTime.now());
final DateTime earliestBackToTornDelayed = DateTime.now().add(Duration(seconds: extraTime.inSeconds));
```

This simplifies to just `_delayedDepartureTime`, completely missing the round-trip travel time. As a result, the bars/cooldown analysis for delayed departures was showing incorrect information.

**The fix:** Properly calculate the return time as:
```dart
final DateTime earliestBackToTornDelayed = _delayedDepartureTime.add(Duration(seconds: _travelSeconds * 2));
```

This ensures the analysis correctly accounts for: departure time + travel to destination + travel back to Torn.

## Test Plan

- [ ] Open Foreign Stocks page
- [ ] Expand a stock card that shows "Travel at X time" (delayed departure)
- [ ] Verify the bars/cooldown analysis in the delayed departure section now correctly reflects when you'd return to Torn