### PR TITLE
docs: add TODO comment explaining disabled inventory API

### DIFF
--- a/lib/pages/travel/foreign_stock_page.dart
+++ b/lib/pages/travel/foreign_stock_page.dart
@@ -1515,10 +1515,12 @@ class ForeignStockPageState extends State<ForeignStockPage> {
     _allTornItems = itemsResponse;
   }
 
+  // TODO: Torn removed the inventory API endpoint. They mentioned they would
+  // reinstate it, but haven't yet. This function is kept in case the API
+  // returns. See: https://www.torn.com/forums.php#/p=threads&f=63&t=16146310&b=0&a=0&start=20&to=24014610
   Future inventory() async {
     return null;
 
-    // Removed as per https://www.torn.com/forums.php#/p=threads&f=63&t=16146310&b=0&a=0&start=20&to=24014610
     /*
     dynamic inventoryResponse = await ApiCallsV1.getInventory();
 


### PR DESCRIPTION
## Summary

Adds a clear TODO comment above the `inventory()` function explaining that:
- Torn removed the inventory API endpoint
- They mentioned they would reinstate it, but haven't yet
- The function is kept (commented out) in case the API returns

This replaces the original PR which proposed removing the dead code entirely.

#### Test plan

- [x] Comment is clear and explains the situation
- [x] No functional changes