### PR TITLE
refactor: consolidate country mapping into CountryHelper class

### DIFF
--- a/lib/models/travel/foreign_stock_in.dart
+++ b/lib/models/travel/foreign_stock_in.dart
@@ -119,3 +119,95 @@ enum CountryName {
   UNITED_KINGDOM,
   TORN,
 }
+
+/// Centralized country mapping utilities
+/// Consolidates all country code/name conversions in one place
+class CountryHelper {
+  /// 3-letter API code to CountryName enum
+  static const Map<String, CountryName> codeToCountry = {
+    'arg': CountryName.ARGENTINA,
+    'can': CountryName.CANADA,
+    'cay': CountryName.CAYMAN_ISLANDS,
+    'chi': CountryName.CHINA,
+    'haw': CountryName.HAWAII,
+    'jap': CountryName.JAPAN,
+    'mex': CountryName.MEXICO,
+    'sou': CountryName.SOUTH_AFRICA,
+    'swi': CountryName.SWITZERLAND,
+    'uae': CountryName.UAE,
+    'uni': CountryName.UNITED_KINGDOM,
+  };
+
+  /// CountryName enum to full display name
+  static const Map<CountryName, String> countryToFullName = {
+    CountryName.ARGENTINA: 'Argentina',
+    CountryName.CANADA: 'Canada',
+    CountryName.CAYMAN_ISLANDS: 'Cayman Islands',
+    CountryName.CHINA: 'China',
+    CountryName.HAWAII: 'Hawaii',
+    CountryName.JAPAN: 'Japan',
+    CountryName.MEXICO: 'Mexico',
+    CountryName.SOUTH_AFRICA: 'South Africa',
+    CountryName.SWITZERLAND: 'Switzerland',
+    CountryName.UAE: 'UAE',
+    CountryName.UNITED_KINGDOM: 'UK',
+    CountryName.TORN: 'Torn',
+  };
+
+  /// Full/plain name to CountryName enum
+  static const Map<String, CountryName> nameToCountry = {
+    'Argentina': CountryName.ARGENTINA,
+    'Canada': CountryName.CANADA,
+    'Cayman Islands': CountryName.CAYMAN_ISLANDS,
+    'China': CountryName.CHINA,
+    'Hawaii': CountryName.HAWAII,
+    'Japan': CountryName.JAPAN,
+    'Mexico': CountryName.MEXICO,
+    'South Africa': CountryName.SOUTH_AFRICA,
+    'Switzerland': CountryName.SWITZERLAND,
+    'UAE': CountryName.UAE,
+    'United Kingdom': CountryName.UNITED_KINGDOM,
+    'UK': CountryName.UNITED_KINGDOM,
+    'Torn': CountryName.TORN,
+  };
+
+  /// Full name to 3-letter API code (for Firebase cache conversion)
+  static const Map<String, String> nameToCode = {
+    'Argentina': 'arg',
+    'Canada': 'can',
+    'Cayman Islands': 'cay',
+    'China': 'chi',
+    'Hawaii': 'haw',
+    'Japan': 'jap',
+    'Mexico': 'mex',
+    'South Africa': 'sou',
+    'Switzerland': 'swi',
+    'UAE': 'uae',
+    'UK': 'uni',
+    'United Kingdom': 'uni',
+  };
+
+  /// Get CountryName from 3-letter code, returns null if not found
+  static CountryName? fromCode(String? code) {
+    if (code == null) return null;
+    return codeToCountry[code.toLowerCase()];
+  }
+
+  /// Get CountryName from plain/full name, returns TORN if not found
+  static CountryName fromName(String? name) {
+    if (name == null) return CountryName.TORN;
+    return nameToCountry[name] ?? CountryName.TORN;
+  }
+
+  /// Get full display name from CountryName
+  static String getFullName(CountryName? country) {
+    if (country == null) return 'Unknown';
+    return countryToFullName[country] ?? 'Unknown';
+  }
+
+  /// Get 3-letter code from full name
+  static String? getCodeFromName(String? name) {
+    if (name == null) return null;
+    return nameToCode[name];
+  }
+}

--- a/lib/pages/travel/foreign_stock_page.dart
+++ b/lib/pages/travel/foreign_stock_page.dart
@@ -69,12 +69,12 @@ class ForeignStockPageState extends State<ForeignStockPage> {
     final destination = widget.temporaryDestinationCountry;
     if (destination == null || destination.isEmpty) return false;
 
-    return _returnCountryName(destination) != CountryName.TORN;
+    return CountryHelper.fromName(destination) != CountryName.TORN;
   }
 
   CountryName? get _temporaryDestinationCountryName {
     if (!_temporaryDestinationFilterActive) return null;
-    return _returnCountryName(widget.temporaryDestinationCountry);
+    return CountryHelper.fromName(widget.temporaryDestinationCountry);
   }
 
   bool get _hasItemFiltersApplied => _filteredTypes.any((enabled) => !enabled);
@@ -921,7 +921,7 @@ class ForeignStockPageState extends State<ForeignStockPage> {
       ticket: _settingsProvider!.travelTicket,
       activeRestocks: _activeRestocks,
       travelingTimeStamp: _profile!.travel!.timestamp,
-      travelingCountry: _returnCountryName(_profile!.travel!.destination),
+      travelingCountry: CountryHelper.fromName(_profile!.travel!.destination),
       travelingCountryFullName: _profile!.travel!.destination,
       displayShowcase: displayShowcase,
       isDataFromCache: _isDataFromCache,
@@ -1059,43 +1059,10 @@ class ForeignStockPageState extends State<ForeignStockPage> {
             stock.itemType = ItemType.OTHER;
           }
 
-          // Assign actual profit depending on country (+ the country)
+          // Assign country from 3-letter code using centralized helper
           stock.countryCode = countryKey;
-          switch (countryKey) {
-            case 'jap':
-              stock.country = CountryName.JAPAN;
-              stock.countryFullName = "Japan";
-            case 'haw':
-              stock.country = CountryName.HAWAII;
-              stock.countryFullName = "Hawaii";
-            case 'chi':
-              stock.country = CountryName.CHINA;
-              stock.countryFullName = "China";
-            case 'arg':
-              stock.country = CountryName.ARGENTINA;
-              stock.countryFullName = "Argentina";
-            case 'uni':
-              stock.country = CountryName.UNITED_KINGDOM;
-              stock.countryFullName = "UK";
-            case 'cay':
-              stock.country = CountryName.CAYMAN_ISLANDS;
-              stock.countryFullName = "Cayman Islands";
-            case 'sou':
-              stock.country = CountryName.SOUTH_AFRICA;
-              stock.countryFullName = "South Africa";
-            case 'swi':
-              stock.country = CountryName.SWITZERLAND;
-              stock.countryFullName = "Switzerland";
-            case 'mex':
-              stock.country = CountryName.MEXICO;
-              stock.countryFullName = "Mexico";
-            case 'uae':
-              stock.country = CountryName.UAE;
-              stock.countryFullName = "UAE";
-            case 'can':
-              stock.country = CountryName.CANADA;
-              stock.countryFullName = "Canada";
-          }
+          stock.country = CountryHelper.fromCode(countryKey);
+          stock.countryFullName = CountryHelper.getFullName(stock.country);
 
           // Other fields contained in Yata and in Torn
           stock.profit = (stock.value /
@@ -1390,20 +1357,6 @@ class ForeignStockPageState extends State<ForeignStockPage> {
   /// Convert Torn PDA Database format to ForeignStockInModel format
   /// Now uses real data from Realtime Database: id, cost, lastUpdated
   ForeignStockInModel _convertTornPDADataToModel(Map<String, dynamic> tornPDAData) {
-    final countryMapping = {
-      'Argentina': 'arg',
-      'Canada': 'can',
-      'Cayman Islands': 'cay',
-      'China': 'chi',
-      'Hawaii': 'haw',
-      'Japan': 'jap',
-      'Mexico': 'mex',
-      'South Africa': 'sou',
-      'Switzerland': 'swi',
-      'UAE': 'uae',
-      'UK': 'uni', // Firebase might store it as 'UK'
-    };
-
     Map<String, CountryDetails> countries = {};
     Map<String, List<ForeignStock>> stocksByCountry = {};
 
@@ -1428,7 +1381,8 @@ class ForeignStockPageState extends State<ForeignStockPage> {
           // Skip if no country or name
           if (country.isEmpty || name.isEmpty || name == 'Unknown Item') return;
 
-          final countryCode = countryMapping[country] ?? country.toLowerCase().replaceAll(' ', '');
+          // Use centralized helper for country code conversion
+          final countryCode = CountryHelper.getCodeFromName(country) ?? country.toLowerCase().replaceAll(' ', '');
 
           final stock = ForeignStock(
             id: id,
@@ -1965,35 +1919,6 @@ class ForeignStockPageState extends State<ForeignStockPage> {
   Future<void> _onRefresh() async {
     await _fetchApiInformation();
     if (mounted) setState(() {});
-  }
-
-  CountryName _returnCountryName(String? country) {
-    switch (country) {
-      case "Argentina":
-        return CountryName.ARGENTINA;
-      case "Canada":
-        return CountryName.CANADA;
-      case "Cayman Islands":
-        return CountryName.CAYMAN_ISLANDS;
-      case "China":
-        return CountryName.CHINA;
-      case "Hawaii":
-        return CountryName.HAWAII;
-      case "Japan":
-        return CountryName.JAPAN;
-      case "Mexico":
-        return CountryName.MEXICO;
-      case "South Africa":
-        return CountryName.SOUTH_AFRICA;
-      case "Switzerland":
-        return CountryName.SWITZERLAND;
-      case "UAE":
-        return CountryName.UAE;
-      case "United Kingdom":
-        return CountryName.UNITED_KINGDOM;
-      default:
-        return CountryName.TORN;
-    }
   }
 
   Future<void> _refreshMoney() async {

--- a/lib/utils/travel/travel_times.dart
+++ b/lib/utils/travel/travel_times.dart
@@ -9,34 +9,10 @@ enum TravelTicket {
 }
 
 class TravelTimes {
+  /// Converts a plain country name to CountryName enum.
+  /// Delegates to CountryHelper for centralized mapping.
   static CountryName getCountry({required String plainName}) {
-    switch (plainName) {
-      case "Torn":
-        return CountryName.TORN;
-      case "Argentina":
-        return CountryName.ARGENTINA;
-      case "Canada":
-        return CountryName.CANADA;
-      case "Cayman Islands":
-        return CountryName.CAYMAN_ISLANDS;
-      case "China":
-        return CountryName.CHINA;
-      case "Hawaii":
-        return CountryName.HAWAII;
-      case "Japan":
-        return CountryName.JAPAN;
-      case "Mexico":
-        return CountryName.MEXICO;
-      case "South Africa":
-        return CountryName.SOUTH_AFRICA;
-      case "Switzerland":
-        return CountryName.SWITZERLAND;
-      case "UAE":
-        return CountryName.UAE;
-      case "United Kingdom":
-        return CountryName.UNITED_KINGDOM;
-    }
-    return CountryName.TORN;
+    return CountryHelper.fromName(plainName);
   }
 
   /// Provide either a capitalized ("Argentina") name for [countryName] or a CountryName for [code]


### PR DESCRIPTION
## Summary

Creates a centralized `CountryHelper` class that consolidates all country code/name conversion logic that was previously duplicated across multiple files:

- `TravelTimes.getCountry()` switch statement (28 lines)
- `_returnCountryName()` function in `foreign_stock_page.dart` (28 lines)
- Switch statement in `_fetchApiInformation()` (35 lines)
- `countryMapping` map in `_convertTornPDADataToModel()` (12 lines)

The `CountryHelper` class provides:
- `codeToCountry`: 3-letter API code to `CountryName` enum
- `countryToFullName`: `CountryName` enum to display name
- `nameToCountry`: Full name to `CountryName` enum
- `nameToCode`: Full name to 3-letter code
- Helper methods: `fromCode()`, `fromName()`, `getFullName()`, `getCodeFromName()`

**Files changed:**
- `lib/models/travel/foreign_stock_in.dart` - Added `CountryHelper` class (+92 lines)
- `lib/pages/travel/foreign_stock_page.dart` - Replaced duplicated mappings with `CountryHelper` calls (-91 lines)
- `lib/utils/travel/travel_times.dart` - Delegated `getCountry()` to `CountryHelper` (-26 lines)

**Net change:** -7 lines (103 added, 110 removed)

#### Test plan

- [ ] Verify foreign stocks page loads correctly
- [ ] Verify country names display correctly for all countries
- [ ] Verify travel time calculations work correctly
- [ ] Verify Firebase cache data conversion works correctly
