### PR TITLE
fix: update userscript wildcard test to match PR #409 behavior

### DIFF
--- a/test/models/userscript_model_test.dart
+++ b/test/models/userscript_model_test.dart
@@ -167,15 +167,14 @@ void main() {
       expect(m.shouldInject('http://www.torn.com/page'), isFalse);
     });
 
-    test('subdomain wildcard *.torn.com (naive: stripped contains check)', () {
-      // NOTE: the current implementation uses url.contains(match.replaceAll("*",""))
-      // which strips wildcards to "://.torn.com/" — this doesn't substring-match
-      // any real URLs. PR #409 replaces this with proper regex-based matching.
+    test('subdomain wildcard *.torn.com matches subdomains correctly', () {
+      // PR #409 implemented proper regex-based matching for wildcard patterns.
+      // *.torn.com should match any subdomain of torn.com (including bare torn.com).
       final m = _model(matches: ['*://*.torn.com/*']);
-      // With naive matching, ://.torn.com/ is never a substring of a real URL:
-      expect(m.shouldInject('https://www.torn.com/page'), isFalse);
-      expect(m.shouldInject('https://api.torn.com/user'), isFalse);
-      expect(m.shouldInject('https://torn.com/page'), isFalse);
+      expect(m.shouldInject('https://www.torn.com/page'), isTrue);
+      expect(m.shouldInject('https://api.torn.com/user'), isTrue);
+      expect(m.shouldInject('https://torn.com/page'), isTrue);
+      // Should NOT match other domains
       expect(m.shouldInject('https://nottorn.com/page'), isFalse);
     });
 


### PR DESCRIPTION
## Summary

The test `subdomain wildcard *.torn.com` was written to document the old "naive" contains-based matching behavior, but PR #409 implemented proper regex-based wildcard matching. This PR updates the test expectations to reflect the correct behavior.

**Changes:**
- `*.torn.com` now properly matches subdomains (`www.torn.com`, `api.torn.com`)
- `*.torn.com` also matches the bare domain (`torn.com`)
- Still correctly rejects non-matching domains (`nottorn.com`)

This fixes the failing CI test on the develop branch.

#### Test plan

- [x] Test passes locally (expectations now match implementation)