### PR TITLE
docs: add link to local build instructions in Docker README

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,8 @@
 Run Flutter tests, analysis and builds without installing anything
 except Docker.
 
+> **Prefer a local Flutter install?** See [Building from Source](../docs/README.md#building-from-source) in the main docs.
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) (20.10+)


### PR DESCRIPTION
## Summary

Adds a note at the top of the Docker README pointing users to the local build instructions if they prefer not to use Docker.

This makes it easier for contributors to find the right setup guide for their preference.