### PR TITLE
perf: add const constructors and use ListView.builder

### DIFF
--- a/lib/widgets/friends/friends_list.dart
+++ b/lib/widgets/friends/friends_list.dart
@@ -16,28 +16,41 @@ class FriendsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final friendsProvider = Provider.of<FriendsProvider>(context, listen: false);
+    final String filter = friendsProvider.currentFilter;
+
+    // Filter friends by name
+    final filteredFriends = friends
+        .where((f) => f.name!.toUpperCase().contains(filter.toUpperCase()))
+        .toList();
+
+    // +1 for bottom padding SizedBox
+    final itemCount = filteredFriends.length + 1;
+
     if (MediaQuery.orientationOf(context) == Orientation.portrait) {
-      return ListView(children: getChildrenFriends(context));
+      return ListView.builder(
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          if (index == filteredFriends.length) {
+            // Avoid collisions with SnackBar
+            return const SizedBox(height: 50);
+          }
+          return FriendCard(friendModel: filteredFriends[index]);
+        },
+      );
     } else {
-      return ListView(
+      return ListView.builder(
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
-        children: getChildrenFriends(context),
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          if (index == filteredFriends.length) {
+            // Avoid collisions with SnackBar
+            return const SizedBox(height: 50);
+          }
+          return FriendCard(friendModel: filteredFriends[index]);
+        },
       );
     }
-  }
-
-  List<Widget> getChildrenFriends(BuildContext _) {
-    final friendsProvider = Provider.of<FriendsProvider>(_, listen: false);
-    final String filter = friendsProvider.currentFilter;
-    List<Widget> filteredCards = <Widget>[];
-    for (final thisFriend in friends) {
-      if (thisFriend.name!.toUpperCase().contains(filter.toUpperCase())) {
-        filteredCards.add(FriendCard(friendModel: thisFriend));
-      }
-    }
-    // Avoid collisions with SnackBar
-    filteredCards.add(const SizedBox(height: 50));
-    return filteredCards;
   }
 }

--- a/lib/widgets/trades/trades_widget.dart
+++ b/lib/widgets/trades/trades_widget.dart
@@ -774,7 +774,7 @@ class TradesWidgetState extends State<TradesWidget> {
 
         if (tradeSyncListedItems == 0) {
           items.add(Padding(
-            padding: EdgeInsets.only(bottom: 6),
+            padding: const EdgeInsets.only(bottom: 6),
             child: Text(
               'PRICED ITEMS',
               style: TextStyle(color: _tradeSyncColor(), fontSize: 8, fontWeight: FontWeight.bold),
@@ -908,8 +908,8 @@ class TradesWidgetState extends State<TradesWidget> {
                   ),
                 ),
               ),
-              SizedBox(width: 4),
-              Icon(Icons.warning_amber_outlined, size: 16, color: Colors.orange),
+              const SizedBox(width: 4),
+              const Icon(Icons.warning_amber_outlined, size: 16, color: Colors.orange),
             ],
           ),
         );


### PR DESCRIPTION
## Summary

Two small performance improvements:

### 1. Add `const` constructors in trades_widget.dart
- Line 777: `const EdgeInsets.only(bottom: 6)`
- Line 911: `const SizedBox(width: 4)`
- Line 912: `const Icon(...)`

Using `const` allows Flutter to reuse widget instances instead of creating new ones on each rebuild.

### 2. Convert FriendsList to ListView.builder
- Changed from `ListView(children: getChildrenFriends())` to `ListView.builder`
- **Before:** All friend cards built upfront, even if not visible
- **After:** Only visible cards are built (lazy loading)

This improves scroll performance and reduces memory usage for users with many friends.

#### Test plan

- [x] Analyzer passes with no issues
- [ ] Friends list scrolls smoothly
- [ ] Trades widget displays correctly