### PR TITLE
perf: add listen: false to Provider.of in card widgets

### DIFF
--- a/lib/widgets/chaining/retal_card.dart
+++ b/lib/widgets/chaining/retal_card.dart
@@ -82,7 +82,7 @@ class RetalCardState extends State<RetalCard> {
   @override
   Widget build(BuildContext context) {
     _retal = widget.retalModel;
-    _themeProvider = Provider.of<ThemeProvider>(context);
+    _themeProvider = Provider.of<ThemeProvider>(context, listen: false);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 5),

--- a/lib/widgets/chaining/target_card.dart
+++ b/lib/widgets/chaining/target_card.dart
@@ -74,7 +74,7 @@ class TargetCardState extends State<TargetCard> {
   Widget build(BuildContext context) {
     _target = widget.targetModel;
     _returnLastUpdated();
-    _themeProvider = Provider.of<ThemeProvider>(context);
+    _themeProvider = Provider.of<ThemeProvider>(context, listen: false);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 5),
       child: Card(

--- a/lib/widgets/chaining/war_card.dart
+++ b/lib/widgets/chaining/war_card.dart
@@ -156,7 +156,7 @@ class WarCardState extends State<WarCard> {
   @override
   Widget build(BuildContext context) {
     _returnLastUpdated();
-    _themeProvider = Provider.of<ThemeProvider>(context);
+    _themeProvider = Provider.of<ThemeProvider>(context, listen: false);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 3),
       child: Card(

--- a/lib/widgets/friends/friend_card.dart
+++ b/lib/widgets/friends/friend_card.dart
@@ -57,7 +57,7 @@ class FriendCardState extends State<FriendCard> {
     _friend = widget.friendModel;
     _returnLastUpdated();
     _friendsProvider = Provider.of<FriendsProvider>(context, listen: false);
-    _themeProvider = Provider.of<ThemeProvider>(context);
+    _themeProvider = Provider.of<ThemeProvider>(context, listen: false);
     return Slidable(
       startActionPane: ActionPane(
         extentRatio: 0.25,

--- a/lib/widgets/stakeouts/stakeout_card.dart
+++ b/lib/widgets/stakeouts/stakeout_card.dart
@@ -80,7 +80,7 @@ class StakeoutCardState extends State<StakeoutCard> {
 
   @override
   Widget build(BuildContext context) {
-    _themeProvider = Provider.of<ThemeProvider>(context);
+    _themeProvider = Provider.of<ThemeProvider>(context, listen: false);
     return Slidable(
       startActionPane: ActionPane(
         motion: const ScrollMotion(),


### PR DESCRIPTION
## Summary

**High impact, minimal change.**

Card widgets were using `Provider.of<ThemeProvider>(context)` without `listen: false` in their `build()` methods. This caused ALL cards to rebuild whenever ThemeProvider notified listeners.

### The Problem
- Target lists, war member lists, friends lists can have **hundreds of cards**
- Each card was subscribed to ThemeProvider changes
- Any ThemeProvider notification triggered rebuilds of ALL cards
- Theme changes are rare (user manually switches theme), so this subscription was wasteful

### The Fix
Add `listen: false` to 5 card widgets:
- `target_card.dart`
- `war_card.dart`
- `retal_card.dart`
- `friend_card.dart`
- `stakeout_card.dart`

### Why This Is Safe
- Theme only changes when user explicitly switches it in settings
- When theme changes, the entire app rebuilds anyway (parent widgets rebuild)
- Cards don't need to independently react to theme changes

#### Test plan

- [x] Analyzer passes
- [ ] Cards display correctly with current theme
- [ ] Theme switching still works (cards update when navigating back to list)