### PR TITLE
Fix projected restock time showing 'unknown' unnecessarily

### DIFF
--- a/lib/widgets/travel/foreign_stock_card.dart
+++ b/lib/widgets/travel/foreign_stock_card.dart
@@ -1131,6 +1131,13 @@ class ForeignStockCardState extends State<ForeignStockCard> {
       final lastEmptyDateTime = DateTime.fromMillisecondsSinceEpoch(lastEmpty * 1000);
       _projectedRestockDateTime = lastEmptyDateTime.add(Duration(seconds: _averageTimeToRestock));
 
+      // If the projected restock is in the past, advance by whole restock cycles until it's in the future
+      if (_averageTimeToRestock > 0) {
+        while (_projectedRestockDateTime.isBefore(DateTime.now())) {
+          _projectedRestockDateTime = _projectedRestockDateTime.add(Duration(seconds: _averageTimeToRestock));
+        }
+      }
+
       // CURRENT DEPLETION TREND
       if (widget.foreignStock.quantity! > 0) {
         final inverseList = [];


### PR DESCRIPTION
## Summary

- The projected restock time (`lastEmpty + averageTimeToRestock`) often lands in the past when an item has gone through multiple restock/depletion cycles since `lastEmpty` was recorded. This causes the UI to show "unknown" even though we have valid average restock data.
- Fix: advance the projection forward by whole restock cycles until it's in the future. Guarded by `averageTimeToRestock > 0` to avoid an infinite loop when there's genuinely no data.
- This also enables the existing delayed departure feature ("Travel at X:XX") to work for items that previously showed "unknown", since that feature depends on a valid projected restock time.

## What changed

`foreign_stock_card.dart` — 5 lines added after the projected restock calculation (line ~1132):

```dart
if (_averageTimeToRestock > 0) {
  while (_projectedRestockDateTime.isBefore(DateTime.now())) {
    _projectedRestockDateTime = _projectedRestockDateTime.add(
      Duration(seconds: _averageTimeToRestock),
    );
  }
}
```

## Test plan

- [x] All 88 existing tests pass
- [ ] Verify in-app that items previously showing "unknown" now display a projected restock time
- [ ] Verify that items with no Firestore restock data still correctly show "unknown"
- [ ] Verify delayed departure ("Travel at X:XX") works for items that previously showed "unknown"