### PR TITLE
ci: add iOS PR build check

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,9 +7,10 @@
 | **analyze** | `flutter analyze` — static analysis, catches type errors and lint violations | ~2 min |
 | **test** | `flutter test --coverage` — runs everything under `test/` | ~2 min |
 | **build** | `flutter build apk --debug` — proves the project still compiles | ~5 min |
+| **ios** | `flutter build ios --no-codesign` — proves the iOS project still compiles | ~10-15 min |
 
 `analyze` and `test` run **in parallel** on every push to `develop` or `master`
-and every PR targeting either branch. `build` only runs on **pull requests**
+and every PR targeting either branch. `build` and `ios` only run on **pull requests**
 (skipped on direct pushes to save time).
 
 ## Costs
@@ -25,6 +26,10 @@ imports resolve. This means CI builds with **placeholder values** — features
 that need real credentials (YATA proxy, native auth, TAC) won't work, but
 analysis and tests still pass.
 
+The iOS build also creates temporary CI-only stubs for `ios/Flutter/Secrets.xcconfig`
+and `ios/Runner/GoogleService-Info.plist`. Those files are intentionally not
+committed because real local/release builds need private Google/Firebase values.
+
 ## Updating the Flutter version
 
 Change `FLUTTER_VERSION` in the `env:` block at the top of `ci.yml`. The
@@ -35,7 +40,8 @@ Change `FLUTTER_VERSION` in the `env:` block at the top of `ci.yml`. The
 Common additions:
 - **Windows build**: add another job with `runs-on: windows-latest` and
   `flutter build windows`
-- **iOS build**: needs `runs-on: macos-latest` + Xcode (free but slower)
+- **iOS build**: already runs on PRs using `macos-latest` + Xcode. Keep it PR-only unless
+  we explicitly want slower direct-push checks too.
 - **Code coverage thresholds**: parse `coverage/lcov.info` and fail if
   coverage drops below a target
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@
 #   1. analyze  — dart static analysis (push + PR)
 #   2. test     — flutter unit & widget tests (push + PR)
 #   3. build    — confirms the Android APK still compiles (PR only)
+#   4. ios      — confirms the iOS app still compiles without signing (PR only)
 #
 # All jobs run on GitHub-hosted runners. Public repos get unlimited
 # free minutes, so this costs nothing.
@@ -148,3 +149,69 @@ jobs:
 
       - name: Build debug APK
         run: flutter build apk --debug
+
+  # ──────────────────────────────────────────────
+  # 4. iOS build — proves the iOS project compiles (PR only)
+  # ──────────────────────────────────────────────
+  ios:
+    name: Build iOS
+    if: github.event_name == 'pull_request'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Copy config stubs
+        run: |
+          cd lib/config
+          for f in *.dart.example; do
+            cp "$f" "${f%.example}"
+          done
+          cp firebase_options.dart.example ../firebase_options.dart
+          cd ..
+          mkdir -p torn-pda-native/auth torn-pda-native/stats
+          cp config/native_auth_models.dart.example    torn-pda-native/auth/native_auth_models.dart
+          cp config/native_auth_provider.dart.example   torn-pda-native/auth/native_auth_provider.dart
+          cp config/native_user_provider.dart.example   torn-pda-native/auth/native_user_provider.dart
+          cp config/native_login_widget.dart.example    torn-pda-native/auth/native_login_widget.dart
+          cp config/stats_controller.dart.example       torn-pda-native/stats/stats_controller.dart
+
+      - name: Create iOS CI stubs
+        run: |
+          cat > ios/Flutter/Secrets.xcconfig <<'EOF'
+          GOOGLE_CLIENT_ID=stub.apps.googleusercontent.com
+          GOOGLE_REVERSED_CLIENT_ID=com.googleusercontent.apps.stub
+          EOF
+
+          cat > ios/Runner/GoogleService-Info.plist <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>API_KEY</key>
+            <string>stub</string>
+            <key>CLIENT_ID</key>
+            <string>stub.apps.googleusercontent.com</string>
+            <key>GCM_SENDER_ID</key>
+            <string>000000000000</string>
+            <key>GOOGLE_APP_ID</key>
+            <string>1:000000000000:ios:0000000000000000</string>
+            <key>PLIST_VERSION</key>
+            <string>1</string>
+            <key>BUNDLE_ID</key>
+            <string>com.manuito.tornpda</string>
+            <key>PROJECT_ID</key>
+            <string>torn-pda-stub</string>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build iOS without code signing
+        run: flutter build ios --no-codesign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,5 +213,8 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Install FlutterFire CLI
+        run: dart pub global activate flutterfire_cli
+
       - name: Build iOS without code signing
         run: flutter build ios --no-codesign


### PR DESCRIPTION
## Summary

Adds a PR-only iOS build check to CI so we catch iOS compile breakage before merging changes that may have been developed mostly on Android/Linux.

The new `Build iOS` job runs on `macos-latest` and uses:

```bash
flutter build ios --no-codesign
```

This keeps the check focused on compile health without requiring Apple signing credentials.

## Why PR-only

macOS runners are slower than the existing Ubuntu jobs, so this runs only on pull requests, like the Android APK build. That gives us the important safety net before merge without making every direct push slower.

## CI stubs

The iOS project references private local files that are not committed, so the job creates temporary CI-only stubs for:

- `ios/Flutter/Secrets.xcconfig`
- `ios/Runner/GoogleService-Info.plist`

These are only created inside the workflow and do not affect real local or release builds.

## Notes

This is intended as a first iOS safety check. It does not boot an iPhone simulator or run UI tests; it verifies that the iOS project still compiles without code signing.