### PR TITLE
Disable iOS Game Mode to reduce battery drain

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -223,6 +223,8 @@
 				<string>Viewer</string>
 			</dict>
 		</array>
+		<key>GCSupportsGameMode</key>
+		<false />
 		<key>NSSupportsLiveActivities</key>
 		<true />
 		<key>UTExportedTypeDeclarations</key>


### PR DESCRIPTION
## Summary

Adds `GCSupportsGameMode = false` to `Info.plist` so iOS doesn't activate Game Mode for Torn PDA.

Game Mode boosts GPU/CPU performance and changes background task behavior, which is great for actual games but unnecessary for PDA — it just burns through battery for no reason.

Reference: https://developer.apple.com/documentation/bundleresources/information-property-list/lssupportsgamemode

Closes #435

## What changed

`ios/Runner/Info.plist` — 2 lines added:
```xml
<key>GCSupportsGameMode</key>
<false />
```

## Test plan

- [x] iOS build passes in CI
- [ ] Verify on device that Game Mode no longer activates when using PDA