### PR TITLE
Add 'Sort by rarity' option to foreign stocks

### DIFF
--- a/lib/models/travel/foreign_stock_sort.dart
+++ b/lib/models/travel/foreign_stock_sort.dart
@@ -1,4 +1,4 @@
-enum StockSortType { country, name, type, quantity, price, value, profit, arrivalTime, inventoryQuantity }
+enum StockSortType { country, name, type, quantity, price, value, profit, arrivalTime, inventoryQuantity, rarity }
 
 class StockSort {
   StockSortType? type;
@@ -22,6 +22,8 @@ class StockSort {
         description = 'Sort by profit';
       case StockSortType.arrivalTime:
         description = 'Sort by arrival time';
+      case StockSortType.rarity:
+        description = 'Sort by rarity';
       /*
       case StockSortType.inventoryQuantity:
         description = 'Sort by quantity (inventory)';

--- a/lib/pages/travel/foreign_stock_page.dart
+++ b/lib/pages/travel/foreign_stock_page.dart
@@ -182,6 +182,7 @@ class ForeignStockPageState extends State<ForeignStockPage> {
     StockSort(type: StockSortType.value),
     StockSort(type: StockSortType.profit),
     StockSort(type: StockSortType.arrivalTime),
+    StockSort(type: StockSortType.rarity),
   ];
 
   final List<ForeignStock> _hiddenStocks = <ForeignStock>[];
@@ -1745,6 +1746,13 @@ class ForeignStockPageState extends State<ForeignStockPage> {
         case StockSortType.arrivalTime:
           _filteredStocksCards.sort((a, b) => a.arrivalTime.compareTo(b.arrivalTime));
           Prefs().setStockSort('arrivalTime');
+        case StockSortType.rarity:
+          _filteredStocksCards.sort((a, b) {
+            final aCirculation = _allTornItems?.items?[a.id!.toString()]?.circulation ?? 999999;
+            final bCirculation = _allTornItems?.items?[b.id!.toString()]?.circulation ?? 999999;
+            return aCirculation.compareTo(bCirculation);
+          });
+          Prefs().setStockSort('rarity');
         /*
         case StockSortType.inventoryQuantity:
           _filteredStocksCards.sort((a, b) => b.inventoryQuantity!.compareTo(a.inventoryQuantity!));
@@ -1800,6 +1808,8 @@ class ForeignStockPageState extends State<ForeignStockPage> {
       sortType = StockSortType.profit;
     } else if (sortString == 'arrivalTime') {
       sortType = StockSortType.arrivalTime;
+    } else if (sortString == 'rarity') {
+      sortType = StockSortType.rarity;
     } else if (sortString == 'inventoryQuantity') {
       // Removed as per https://www.torn.com/forums.php#/p=threads&f=63&t=16146310&b=0&a=0&start=20&to=24014610
       //sortType = StockSortType.inventoryQuantity;


### PR DESCRIPTION
## Summary

Adds a new "Sort by rarity" option to the foreign stocks sort menu. Items are sorted by circulation count (ascending), so the rarest items show up first.

The circulation data already comes from the Torn API items endpoint and is loaded in `_allTornItems` — this just adds it as a sort option alongside the existing ones (country, name, type, quantity, price, value, profit, arrival time).

Closes #221

## What changed

**`foreign_stock_sort.dart`**
- Added `rarity` to the `StockSortType` enum
- Added description: "Sort by rarity"

**`foreign_stock_page.dart`**
- Added `StockSort(type: StockSortType.rarity)` to the popup menu choices
- Added sort logic: compares `circulation` from `_allTornItems` (lower = rarer = first)
- Added preference restore for `'rarity'` sort string

## Test plan

- [x] All 88 existing tests pass
- [ ] Open Foreign Stocks page, tap sort icon, select "Sort by rarity"
- [ ] Verify rarest items (lowest circulation) appear at the top
- [ ] Close and reopen Foreign Stocks — verify sort preference is remembered