### PR TITLE
Add item blacklist to foreign stocks

### DIFF
--- a/lib/pages/travel/foreign_stock_page.dart
+++ b/lib/pages/travel/foreign_stock_page.dart
@@ -185,6 +185,7 @@ class ForeignStockPageState extends State<ForeignStockPage> {
   ];
 
   final List<ForeignStock> _hiddenStocks = <ForeignStock>[];
+  final Set<int> _blacklistedItemIds = <int>{};
 
   late StreamSubscription _willPopSubscription;
 
@@ -404,7 +405,7 @@ class ForeignStockPageState extends State<ForeignStockPage> {
         ),
         IconButton(
           icon: const Icon(MdiIcons.eyeRemoveOutline),
-          onPressed: _hiddenStocks.isEmpty
+          onPressed: _hiddenStocks.isEmpty && _blacklistedItemIds.isEmpty
               ? null
               : () {
                   showDialog<void>(
@@ -412,8 +413,11 @@ class ForeignStockPageState extends State<ForeignStockPage> {
                     builder: (BuildContext context) {
                       return HiddenForeignStockDialog(
                         hiddenStocks: _hiddenStocks,
+                        blacklistedItemIds: _blacklistedItemIds,
+                        allTornItems: _allTornItems,
                         themeProvider: _themeProvider,
                         unhide: _unhideMember,
+                        unblacklist: _unblacklistItem,
                       );
                     },
                   );
@@ -687,11 +691,12 @@ class ForeignStockPageState extends State<ForeignStockPage> {
       visibleStocks = visibleStocks.where((stock) => stock.country == temporaryCountry);
     }
 
-    if (_hiddenStocks.isEmpty) {
+    if (_hiddenStocks.isEmpty && _blacklistedItemIds.isEmpty) {
       return List<ForeignStock>.from(visibleStocks);
     }
 
     return visibleStocks.where((stock) {
+      if (_blacklistedItemIds.contains(stock.id)) return false;
       for (final h in _hiddenStocks) {
         if (h.id == stock.id && h.countryCode == stock.countryCode) {
           return false;
@@ -808,15 +813,20 @@ class ForeignStockPageState extends State<ForeignStockPage> {
     );
 
     Widget hiddenDetails = const SizedBox.shrink();
-    if (_hiddenStocks.isNotEmpty) {
+    if (_hiddenStocks.isNotEmpty || _blacklistedItemIds.isNotEmpty) {
+      final parts = <String>[];
+      if (_hiddenStocks.isNotEmpty) {
+        parts.add('${_hiddenStocks.length} hidden stock${_hiddenStocks.length == 1 ? "" : "s"}');
+      }
+      if (_blacklistedItemIds.isNotEmpty) {
+        parts.add('${_blacklistedItemIds.length} blacklisted item${_blacklistedItemIds.length == 1 ? "" : "s"}');
+      }
       hiddenDetails = Padding(
         padding: const EdgeInsets.fromLTRB(20, 0, 20, 15),
         child: Row(
           children: <Widget>[
             Text(
-              'There ${_hiddenStocks.length == 1 ? "is" : "are"} '
-              '${_hiddenStocks.length}'
-              ' hidden stock${_hiddenStocks.length == 1 ? "" : "s"}',
+              parts.join(', '),
               style: TextStyle(fontSize: 11, color: Colors.orange[800]),
             ),
           ],
@@ -918,6 +928,7 @@ class ForeignStockPageState extends State<ForeignStockPage> {
       flagPressedCallback: _onFlagPressed,
       requestMoneyRefresh: _refreshMoney,
       memberHiddenCallback: _hideMember,
+      memberBlacklistCallback: _blacklistItem,
       ticket: _settingsProvider!.travelTicket,
       activeRestocks: _activeRestocks,
       travelingTimeStamp: _profile!.travel!.timestamp,
@@ -1818,6 +1829,12 @@ class ForeignStockPageState extends State<ForeignStockPage> {
     for (final s in savedHiddenRaw) {
       _hiddenStocks.add(foreignStockFromJson(s));
     }
+
+    List<String> savedBlacklist = await Prefs().getBlacklistedForeignStockItems();
+    for (final s in savedBlacklist) {
+      final id = int.tryParse(s);
+      if (id != null) _blacklistedItemIds.add(id);
+    }
   }
 
   Future<void> _showOptionsDialog() {
@@ -1958,18 +1975,45 @@ class ForeignStockPageState extends State<ForeignStockPage> {
     }
     Prefs().setHiddenForeignStocks(hiddenSaveList);
   }
+
+  void _blacklistItem(ForeignStock stock) {
+    if (stock.id == null || _blacklistedItemIds.contains(stock.id)) return;
+    setState(() {
+      _blacklistedItemIds.add(stock.id!);
+    });
+    _saveBlacklistedItems();
+  }
+
+  void _unblacklistItem(int id) {
+    setState(() {
+      _blacklistedItemIds.remove(id);
+    });
+    _saveBlacklistedItems();
+  }
+
+  void _saveBlacklistedItems() {
+    Prefs().setBlacklistedForeignStockItems(
+      _blacklistedItemIds.map((id) => id.toString()).toList(),
+    );
+  }
 }
 
 class HiddenForeignStockDialog extends StatefulWidget {
   final ThemeProvider? themeProvider;
   final List<ForeignStock> hiddenStocks;
+  final Set<int> blacklistedItemIds;
+  final ItemsModel? allTornItems;
   final Function(int?, String?) unhide;
+  final Function(int) unblacklist;
 
   const HiddenForeignStockDialog({
     super.key,
     required this.themeProvider,
     required this.hiddenStocks,
+    required this.blacklistedItemIds,
+    required this.allTornItems,
     required this.unhide,
+    required this.unblacklist,
   });
 
   @override
@@ -1979,7 +2023,8 @@ class HiddenForeignStockDialog extends StatefulWidget {
 class HiddenForeignStockDialogState extends State<HiddenForeignStockDialog> {
   @override
   Widget build(BuildContext context) {
-    List<Widget> hiddenCards = buildCards(widget.hiddenStocks, context);
+    List<Widget> hiddenCards = _buildHiddenCards(context);
+    List<Widget> blacklistCards = _buildBlacklistCards(context);
     return AlertDialog(
       backgroundColor: widget.themeProvider!.secondBackground,
       shape: RoundedRectangleBorder(
@@ -1999,27 +2044,43 @@ class HiddenForeignStockDialogState extends State<HiddenForeignStockDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text(
-              "Reset hidden stocks",
-              style: TextStyle(fontSize: 14),
-            ),
-            const SizedBox(height: 15),
-            Flexible(
-              child: ListView(
-                shrinkWrap: true,
-                children: hiddenCards,
+            if (hiddenCards.isNotEmpty) ...[
+              const Text(
+                "Hidden stocks",
+                style: TextStyle(fontSize: 14),
               ),
-            ),
+              const SizedBox(height: 10),
+              Flexible(
+                child: ListView(
+                  shrinkWrap: true,
+                  children: hiddenCards,
+                ),
+              ),
+            ],
+            if (hiddenCards.isNotEmpty && blacklistCards.isNotEmpty) const SizedBox(height: 15),
+            if (blacklistCards.isNotEmpty) ...[
+              const Text(
+                "Blacklisted items",
+                style: TextStyle(fontSize: 14),
+              ),
+              const SizedBox(height: 10),
+              Flexible(
+                child: ListView(
+                  shrinkWrap: true,
+                  children: blacklistCards,
+                ),
+              ),
+            ],
           ],
         ),
       ),
     );
   }
 
-  List<Widget> buildCards(List<ForeignStock> hiddenStocks, BuildContext context) {
-    List<Widget> hiddenCards = <Widget>[];
-    for (final ForeignStock s in hiddenStocks) {
-      hiddenCards.add(
+  List<Widget> _buildHiddenCards(BuildContext context) {
+    List<Widget> cards = <Widget>[];
+    for (final ForeignStock s in widget.hiddenStocks) {
+      cards.add(
         Row(
           children: [
             IconButton(
@@ -2029,7 +2090,7 @@ class HiddenForeignStockDialogState extends State<HiddenForeignStockDialog> {
                   widget.unhide(s.id, s.countryCode);
                 });
 
-                if (widget.hiddenStocks.isEmpty) {
+                if (widget.hiddenStocks.isEmpty && widget.blacklistedItemIds.isEmpty) {
                   Navigator.of(context).pop();
                 }
               },
@@ -2064,6 +2125,44 @@ class HiddenForeignStockDialogState extends State<HiddenForeignStockDialog> {
         ),
       );
     }
-    return hiddenCards;
+    return cards;
+  }
+
+  List<Widget> _buildBlacklistCards(BuildContext context) {
+    List<Widget> cards = <Widget>[];
+    for (final id in widget.blacklistedItemIds) {
+      final itemName = widget.allTornItems?.items?[id.toString()]?.name ?? 'Item #$id';
+      cards.add(
+        Row(
+          children: [
+            IconButton(
+              icon: const Icon(Icons.undo),
+              onPressed: () {
+                setState(() {
+                  widget.unblacklist(id);
+                });
+
+                if (widget.hiddenStocks.isEmpty && widget.blacklistedItemIds.isEmpty) {
+                  Navigator.of(context).pop();
+                }
+              },
+            ),
+            Expanded(
+              child: Card(
+                color: widget.themeProvider!.cardColor,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 3, 8, 3),
+                  child: Text(
+                    '$itemName (all countries)',
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    return cards;
   }
 }

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -197,6 +197,7 @@ class Prefs {
   final String _kForeignStocksDataProvider = "pda_foreignStocksDataProvider";
   final String _kActiveRestocks = "pda_activeRestocks";
   final String _kHiddenForeignStocks = "pda_hiddenForeignStocks";
+  final String _kBlacklistedForeignStockItems = "pda_blacklistedForeignStockItems";
   final String _kCountriesAlphabeticalFilter = "pda_countriesAlphabeticalFilter";
   final String _kRestocksEnabled = "pda_restocksEnabled";
 
@@ -2030,6 +2031,14 @@ class Prefs {
 
   Future setHiddenForeignStocks(List<String> value) async {
     return await PrefsDatabase.setStringList(_kHiddenForeignStocks, value);
+  }
+
+  Future<List<String>> getBlacklistedForeignStockItems() async {
+    return await PrefsDatabase.getStringList(_kBlacklistedForeignStockItems, []);
+  }
+
+  Future setBlacklistedForeignStockItems(List<String> value) async {
+    return await PrefsDatabase.setStringList(_kBlacklistedForeignStockItems, value);
   }
 
   Future<bool> getCountriesAlphabeticalFilter() async {

--- a/lib/widgets/travel/foreign_stock_card.dart
+++ b/lib/widgets/travel/foreign_stock_card.dart
@@ -42,6 +42,7 @@ class ForeignStockCard extends StatefulWidget {
   final Function flagPressedCallback;
   final Function requestMoneyRefresh;
   final Function(ForeignStock) memberHiddenCallback;
+  final Function(ForeignStock) memberBlacklistCallback;
   final TravelTicket? ticket;
   final Map<String, dynamic>? activeRestocks;
   final String? providerName;
@@ -63,6 +64,7 @@ class ForeignStockCard extends StatefulWidget {
     required this.flagPressedCallback,
     required this.requestMoneyRefresh,
     required this.memberHiddenCallback,
+    required this.memberBlacklistCallback,
     required this.ticket,
     required this.activeRestocks,
     required this.travelingTimeStamp,
@@ -182,6 +184,14 @@ class ForeignStockCardState extends State<ForeignStockCard> {
                 icon: MdiIcons.eyeRemoveOutline,
                 onPressed: (context) {
                   widget.memberHiddenCallback(widget.foreignStock);
+                },
+              ),
+              SlidableAction(
+                label: 'Blacklist',
+                backgroundColor: Colors.red[700]!,
+                icon: MdiIcons.closeOctagonOutline,
+                onPressed: (context) {
+                  widget.memberBlacklistCallback(widget.foreignStock);
                 },
               ),
             ],


### PR DESCRIPTION
## Summary

Adds a way to blacklist specific items from the foreign stocks tab entirely, across all countries. This extends the existing per-country "Hide" feature with a more permanent "Blacklist" option.

Closes #212

## How it works

**Swipe left on any stock card** to see two actions:
- **Hide** (blue, existing) — hides that item in that specific country only
- **Blacklist** (red, new) — hides the item from ALL countries

**Managing hidden/blacklisted items:**
- The eye icon in the AppBar opens a dialog showing both sections
- Each entry has an undo button to restore visibility
- Blacklisted items show as "Item Name (all countries)"

**Info banner** below the header shows counts for both hidden stocks and blacklisted items.

## What changed

**`foreign_stock_card.dart`**
- Added `memberBlacklistCallback` parameter
- Added "Blacklist" slide action next to existing "Hide"

**`foreign_stock_page.dart`**
- Added `_blacklistedItemIds` set and save/restore logic
- Updated filter function to skip blacklisted item IDs
- Updated `HiddenForeignStockDialog` to show both sections
- Updated info banner to show both counts

**`shared_prefs.dart`**
- Added `pda_blacklistedForeignStockItems` key with getter/setter

## Test plan

- [x] All 88 existing tests pass
- [ ] Swipe left on a stock card — both "Hide" and "Blacklist" buttons appear
- [ ] Tap "Blacklist" — item disappears from all countries
- [ ] Tap eye icon — dialog shows blacklisted items with undo buttons
- [ ] Undo a blacklisted item — it reappears in all countries
- [ ] Close and reopen the page — blacklist persists
- [ ] Existing "Hide" feature still works as before