### PR TITLE
fix: roll forward foreign stock restock estimate

### DIFF
--- a/lib/widgets/travel/foreign_stock_card.dart
+++ b/lib/widgets/travel/foreign_stock_card.dart
@@ -81,6 +81,8 @@ class ForeignStockCard extends StatefulWidget {
 }
 
 class ForeignStockCardState extends State<ForeignStockCard> {
+  static const _restockSoonMaxAverage = Duration(hours: 5);
+
   final _expandableController = ExpandableController();
 
   Future? _footerInformationRetrieved;
@@ -92,6 +94,8 @@ class ForeignStockCardState extends State<ForeignStockCard> {
   var _averageTimeToRestock = 0;
   var _restockReliability = 0;
   var _projectedRestockDateTime = DateTime.now();
+  var _hasProjectedRestockDateTime = false;
+  var _restockExpectedSoon = false;
   var _depletionTrendPerSecond = 0.0;
 
   int? _invQuantity = 0;
@@ -167,6 +171,42 @@ class ForeignStockCardState extends State<ForeignStockCard> {
     _expandableController.dispose();
     _browserHasClosedSubscription.cancel();
     super.dispose();
+  }
+
+  ({DateTime dateTime, bool expectedSoon}) _nextProjectedRestockDateTime(DateTime lastEmptyDateTime) {
+    final now = DateTime.now();
+    final averageDuration = Duration(seconds: _averageTimeToRestock);
+    var projected = lastEmptyDateTime.add(averageDuration);
+
+    if (!projected.isAfter(now)) {
+      final soonCutoff = projected.add(Duration(seconds: _averageTimeToRestock ~/ 2));
+      if (averageDuration < _restockSoonMaxAverage && now.isBefore(soonCutoff)) {
+        return (dateTime: projected, expectedSoon: true);
+      }
+
+      final elapsedSeconds = now.difference(lastEmptyDateTime).inSeconds;
+      final intervalsToSkip = elapsedSeconds ~/ _averageTimeToRestock + 1;
+      projected = lastEmptyDateTime.add(
+        Duration(seconds: _averageTimeToRestock * intervalsToSkip),
+      );
+    }
+
+    return (dateTime: projected, expectedSoon: false);
+  }
+
+  String _projectedRestockText() {
+    if (!_hasProjectedRestockDateTime ||
+        _projectedRestockDateTime.isAfter(DateTime.now().add(const Duration(days: 7)))) {
+      return 'unknown';
+    }
+
+    if (_restockExpectedSoon) return 'anytime soon';
+
+    return TimeFormatter(
+      inputTime: _projectedRestockDateTime,
+      timeFormatSetting: _settingsProvider.currentTimeFormat,
+      timeZoneSetting: _settingsProvider.currentTimeZone,
+    ).formatHourWithDaysElapsed(includeToday: true);
   }
 
   @override
@@ -488,14 +528,7 @@ class ForeignStockCardState extends State<ForeignStockCard> {
                               ),
                             ),
                             Text(
-                              _projectedRestockDateTime.isAfter(DateTime.now().add(const Duration(days: 7))) ||
-                                      _projectedRestockDateTime.isBefore(DateTime.now().toLocal())
-                                  ? 'unknown'
-                                  : TimeFormatter(
-                                      inputTime: _projectedRestockDateTime,
-                                      timeFormatSetting: _settingsProvider.currentTimeFormat,
-                                      timeZoneSetting: _settingsProvider.currentTimeZone,
-                                    ).formatHourWithDaysElapsed(includeToday: true),
+                              _projectedRestockText(),
                               style: TextStyle(
                                 fontSize: 12,
                                 color: reliabilityColor,
@@ -1139,7 +1172,13 @@ class ForeignStockCardState extends State<ForeignStockCard> {
       // TIMES TO RESTOCK
       final lastEmpty = firestoreData.get('lastEmpty');
       final lastEmptyDateTime = DateTime.fromMillisecondsSinceEpoch(lastEmpty * 1000);
-      _projectedRestockDateTime = lastEmptyDateTime.add(Duration(seconds: _averageTimeToRestock));
+      _hasProjectedRestockDateTime = _averageTimeToRestock > 0 && lastEmpty > 0;
+      _restockExpectedSoon = false;
+      if (_hasProjectedRestockDateTime) {
+        final projectedRestock = _nextProjectedRestockDateTime(lastEmptyDateTime);
+        _projectedRestockDateTime = projectedRestock.dateTime;
+        _restockExpectedSoon = projectedRestock.expectedSoon;
+      }
 
       // CURRENT DEPLETION TREND
       if (widget.foreignStock.quantity! > 0) {


### PR DESCRIPTION
## Summary

Fixes the foreign stock footer so an empty item does not show `unknown` just because the first projected restock time is already in the past.

The app now rolls the projection forward by whole average-restock intervals from `lastEmpty` until it finds the next expected slot after the current time.

## Why

The previous calculation was `lastEmpty + averageRestockTime`. If an item stayed empty longer than that average, the projected time became stale and the UI forced `unknown`, even though we still had enough history to estimate the next interval.

## Logic sanity check

Example:

```text
lastEmpty: 10:00
average restock: 2h
now: 15:15

old projection: 12:00 -> past -> unknown
new projection: 16:00 -> next average slot
```

The helper is only used after `_averageTimeToRestock > 0`, so there is no divide-by-zero path. The UI still shows `unknown` when there is no valid `lastEmpty`, no average restock history, or the rolled-forward estimate is more than 7 days away.

## Verification

- `git diff --check` passed
- GitHub checks passed: Analyze, Test, Cloud Functions, Build APK, Build iOS
- `dart format` could not be run in this shell because `dart` is not on PATH