### PR TITLE
fix: accept comma decimals in stock alerts

### DIFF
--- a/lib/widgets/alerts/share_price_dialog.dart
+++ b/lib/widgets/alerts/share_price_dialog.dart
@@ -171,7 +171,7 @@ class SharePriceDialogState extends State<SharePriceDialog> {
                               keyboardType: const TextInputType.numberWithOptions(decimal: true),
                               inputFormatters: [
                                 FilteringTextInputFormatter.allow(
-                                  RegExp(r'^\+?\d+(\.)?(\d{1,2})?'),
+                                  RegExp(r'^\+?\d+([.,])?(\d{1,2})?'),
                                 )
                               ],
                               onChanged: (gainString) {
@@ -324,7 +324,7 @@ class SharePriceDialogState extends State<SharePriceDialog> {
                               keyboardType: const TextInputType.numberWithOptions(decimal: true),
                               inputFormatters: [
                                 FilteringTextInputFormatter.allow(
-                                  RegExp(r'^\-?\d+(\.)?(\d{1,2})?'),
+                                  RegExp(r'^\-?\d+([.,])?(\d{1,2})?'),
                                 )
                               ],
                               onChanged: (lossString) {
@@ -556,12 +556,12 @@ class SharePriceDialogState extends State<SharePriceDialog> {
 
   double _cleanNumber(String text) {
     if (text.isEmpty) return 0;
-    return double.parse(text);
+    return double.parse(text.replaceAll(",", "."));
   }
 
   double _cleanNumberAbs(String text) {
     if (text.isEmpty) return 0;
-    return double.parse(text).abs();
+    return double.parse(text.replaceAll(",", ".")).abs();
   }
 
   String removeZeroDecimals(double? input) {


### PR DESCRIPTION
## Summary

Fixes #423 by allowing stock gain/loss alert inputs to accept comma decimals as well as dot decimals.

This matters on iOS because the decimal keyboard follows the user locale. Some users get `,` instead of `.`, so values like `0,5` were accepted by the keyboard but could not be parsed by the app.

## What changed

- Gain/loss input formatters now allow `.` or `,` as the decimal separator
- Parsing normalizes `,` to `.` before `double.parse`
- Stored alert values remain normal doubles; no backend/storage format changes

## Verification

- `git diff --check` passed
- Could not run Dart/Flutter checks in this shell because `dart`/`flutter` are not on PATH