### PR TITLE
fix: confirm target deletion when notes exist

### DIFF
--- a/lib/widgets/chaining/targets_list.dart
+++ b/lib/widgets/chaining/targets_list.dart
@@ -78,9 +78,38 @@ class TargetsListState extends State<TargetsList> {
             label: 'Remove',
             backgroundColor: Colors.red,
             icon: Icons.delete,
-            onPressed: (context) {
+            onPressed: (context) async {
+              final target = widget.targets[index];
+              final targetName = target.name ?? "target";
+              final hasNote = playerNote != null && playerNote.note.trim().isNotEmpty;
+
+              if (hasNote) {
+                final confirmed = await showDialog<bool>(
+                  context: this.context,
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('Remove target?'),
+                    content: Text(
+                      '$targetName has a note attached. Removing this target will not delete the note, '
+                      'but the target will be removed from your list.',
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, false),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, true),
+                        child: const Text('Remove'),
+                      ),
+                    ],
+                  ),
+                );
+
+                if (!mounted || confirmed != true) return;
+              }
+
               BotToast.showText(
-                text: 'Deleted ${widget.targets[index].name}!',
+                text: 'Deleted $targetName!',
                 textStyle: const TextStyle(
                   fontSize: 14,
                   color: Colors.white,
@@ -89,7 +118,7 @@ class TargetsListState extends State<TargetsList> {
                 duration: const Duration(seconds: 5),
                 contentPadding: const EdgeInsets.all(10),
               );
-              _targetsProvider.deleteTarget(widget.targets[index]);
+              _targetsProvider.deleteTarget(target);
             },
           ),
         ],


### PR DESCRIPTION
## Summary

Follow-up to #365. Adds a confirmation dialog before removing a chaining target that has a player note attached.

Targets without notes are still removed immediately, so the common fast-delete flow stays unchanged.

## Notes

This keeps the main idea from #365 and adds a couple of small safety details:

- captures the target before awaiting the dialog, so deletion does not depend on `widget.targets[index]` after the async gap
- checks `mounted` after the dialog before touching state/provider behavior
- handles a missing target name gracefully in the dialog/toast

## Verification

- `git diff --check` passed
- Could not run Dart/Flutter checks in this shell because `dart`/`flutter` are not on PATH