### PR TITLE
ci: add experimental verification checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,8 +6,8 @@
 |-----|-------------|-------------|
 | **analyze** | `flutter analyze` — static analysis, catches type errors and lint violations | ~2 min |
 | **test** | `flutter test --coverage` — runs everything under `test/` | ~2 min |
-| **format** | `dart format --set-exit-if-changed lib test` — catches unformatted Dart code | <1 min |
-| **generated** | `dart run build_runner build --delete-conflicting-outputs` then `git diff --exit-code` — catches stale generated Dart output | ~3-6 min |
+| **format** | `dart format --set-exit-if-changed` on changed Dart files under `lib/` and `test/` | <1 min |
+| **generated** | If generator inputs changed, runs `dart run build_runner build --delete-conflicting-outputs` then `git diff --exit-code` | ~3-6 min |
 | **functions** | `npm ci`, `npm run lint`, `npm run build` under `cloud_functions/functions` | ~2 min |
 | **dependency-review** | `actions/dependency-review-action` — fails PRs that introduce high/critical vulnerable dependencies | <1 min |
 | **build** | `flutter build apk --debug` — proves the project still compiles | ~5 min |
@@ -37,8 +37,13 @@ committed because real local/release builds need private Google/Firebase values.
 ## Experimental checks
 
 The `format`, `generated`, and `dependency-review` jobs were added as extra
-verification signals. If they prove too noisy, tune them before making them
-required branch-protection checks.
+verification signals. The format job intentionally checks only changed Dart
+files so existing repo-wide formatting drift does not block unrelated PRs.
+The generated-code job intentionally runs only when generator inputs change,
+because the repo currently has existing generated output drift.
+
+If these jobs prove too noisy, tune them before making them required
+branch-protection checks.
 
 ## Updating the Flutter version
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,13 +6,16 @@
 |-----|-------------|-------------|
 | **analyze** | `flutter analyze` — static analysis, catches type errors and lint violations | ~2 min |
 | **test** | `flutter test --coverage` — runs everything under `test/` | ~2 min |
+| **format** | `dart format --set-exit-if-changed lib test` — catches unformatted Dart code | <1 min |
+| **generated** | `dart run build_runner build --delete-conflicting-outputs` then `git diff --exit-code` — catches stale generated Dart output | ~3-6 min |
 | **functions** | `npm ci`, `npm run lint`, `npm run build` under `cloud_functions/functions` | ~2 min |
+| **dependency-review** | `actions/dependency-review-action` — fails PRs that introduce high/critical vulnerable dependencies | <1 min |
 | **build** | `flutter build apk --debug` — proves the project still compiles | ~5 min |
 | **ios** | `flutter build ios --no-codesign` — proves the iOS project still compiles | ~10-15 min |
 
-`analyze`, `test`, and `functions` run **in parallel** on every push to `develop` or `master`
-and every PR targeting either branch. `build` and `ios` only run on **pull requests**
-(skipped on direct pushes to save time).
+`analyze`, `test`, `format`, `generated`, and `functions` run **in parallel**
+on every push to `develop` or `master` and every PR targeting either branch.
+`dependency-review`, `build`, and `ios` only run on **pull requests**.
 
 ## Costs
 
@@ -30,6 +33,12 @@ analysis and tests still pass.
 The iOS build also creates temporary CI-only stubs for `ios/Flutter/Secrets.xcconfig`
 and `ios/Runner/GoogleService-Info.plist`. Those files are intentionally not
 committed because real local/release builds need private Google/Firebase values.
+
+## Experimental checks
+
+The `format`, `generated`, and `dependency-review` jobs were added as extra
+verification signals. If they prove too noisy, tune them before making them
+required branch-protection checks.
 
 ## Updating the Flutter version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,12 @@
 # Runs on every push and pull request against develop and master.
 #   1. analyze  — dart static analysis (push + PR)
 #   2. test     — flutter unit & widget tests (push + PR)
-#   3. functions — checks Cloud Functions install, lint, and TypeScript build (push + PR)
-#   4. ios      — confirms the iOS app still compiles without signing (PR only)
-#   5. build    — confirms the Android APK still compiles (PR only)
+#   3. format   — checks Dart formatting (push + PR)
+#   4. generated — checks generated Dart files are up to date (push + PR)
+#   5. functions — checks Cloud Functions install, lint, and TypeScript build (push + PR)
+#   6. dependency-review — checks PR dependency changes for vulnerabilities (PR only)
+#   7. ios      — confirms the iOS app still compiles without signing (PR only)
+#   8. build    — confirms the Android APK still compiles (PR only)
 #
 # All jobs run on GitHub-hosted runners. Public repos get unlimited
 # free minutes, so this costs nothing.
@@ -109,7 +112,62 @@ jobs:
           retention-days: 14
 
   # ──────────────────────────────────────────────
-  # 3. Cloud Functions — proves backend functions lint and compile
+  # 3. Formatting — proves Dart files are committed in canonical format
+  # ──────────────────────────────────────────────
+  format:
+    name: Dart Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Check Dart formatting
+        run: dart format --set-exit-if-changed lib test
+
+  # ──────────────────────────────────────────────
+  # 4. Generated code — proves generated Dart files are up to date
+  # ──────────────────────────────────────────────
+  generated:
+    name: Generated Code Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Copy config stubs
+        run: |
+          cd lib/config
+          for f in *.dart.example; do
+            cp "$f" "${f%.example}"
+          done
+          cp firebase_options.dart.example ../firebase_options.dart
+          cd ..
+          mkdir -p torn-pda-native/auth torn-pda-native/stats
+          cp config/native_auth_models.dart.example    torn-pda-native/auth/native_auth_models.dart
+          cp config/native_auth_provider.dart.example   torn-pda-native/auth/native_auth_provider.dart
+          cp config/native_user_provider.dart.example   torn-pda-native/auth/native_user_provider.dart
+          cp config/native_login_widget.dart.example    torn-pda-native/auth/native_login_widget.dart
+          cp config/stats_controller.dart.example       torn-pda-native/stats/stats_controller.dart
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Regenerate Dart outputs
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Check generated files are committed
+        run: git diff --exit-code
+
+  # ──────────────────────────────────────────────
+  # 5. Cloud Functions — proves backend functions lint and compile
   # ──────────────────────────────────────────────
   functions:
     name: Cloud Functions
@@ -136,7 +194,24 @@ jobs:
         run: npm run build
 
   # ──────────────────────────────────────────────
-  # 4. iOS build — proves the iOS project compiles (PR only)
+  # 6. Dependency review — checks new PR dependency changes
+  # ──────────────────────────────────────────────
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+  # ──────────────────────────────────────────────
+  # 7. iOS build — proves the iOS project compiles (PR only)
   # ──────────────────────────────────────────────
   ios:
     name: Build iOS
@@ -205,7 +280,7 @@ jobs:
         run: flutter build ios --no-codesign
 
   # ──────────────────────────────────────────────
-  # 5. Build (APK) — proves the project compiles (PR only)
+  # 8. Build (APK) — proves the project compiles (PR only)
   # ──────────────────────────────────────────────
   build:
     name: Build APK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - name: Check Dart formatting
-        run: dart format --set-exit-if-changed lib test
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Find changed Dart files
+        id: changed-dart
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            base="HEAD~1"
+          fi
+
+          git diff --name-only --diff-filter=ACMRT "$base" HEAD -- 'lib/**/*.dart' 'test/**/*.dart' > /tmp/changed_dart_files.txt
+
+          if [ -s /tmp/changed_dart_files.txt ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            cat /tmp/changed_dart_files.txt
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changed Dart files under lib/ or test/."
+          fi
+
+      - name: Check changed Dart file formatting
+        if: steps.changed-dart.outputs.has_changes == 'true'
+        run: xargs dart format --set-exit-if-changed < /tmp/changed_dart_files.txt
 
   # ──────────────────────────────────────────────
   # 4. Generated code — proves generated Dart files are up to date
@@ -136,13 +165,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
+      - name: Check if generator inputs changed
+        id: generator-inputs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            base="HEAD~1"
+          fi
+
+          git diff --name-only --diff-filter=ACMRT "$base" HEAD -- \
+            'lib/utils/env/env.dart' \
+            'lib/models/api_v2/swagger/**' \
+            'pubspec.yaml' \
+            'pubspec.lock' > /tmp/generator_input_files.txt
+
+          if [ -s /tmp/generator_input_files.txt ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            cat /tmp/generator_input_files.txt
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No generator inputs changed; skipping generated-code drift check."
+          fi
+
       - name: Copy config stubs
+        if: steps.generator-inputs.outputs.has_changes == 'true'
         run: |
           cd lib/config
           for f in *.dart.example; do
@@ -158,12 +217,15 @@ jobs:
           cp config/stats_controller.dart.example       torn-pda-native/stats/stats_controller.dart
 
       - name: Install dependencies
+        if: steps.generator-inputs.outputs.has_changes == 'true'
         run: flutter pub get
 
       - name: Regenerate Dart outputs
+        if: steps.generator-inputs.outputs.has_changes == 'true'
         run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Check generated files are committed
+        if: steps.generator-inputs.outputs.has_changes == 'true'
         run: git diff --exit-code
 
   # ──────────────────────────────────────────────


### PR DESCRIPTION
## DRAFT - do not merge yet

This PR is intentionally opened as a draft to test extra CI checkers before we decide whether they are stable enough to keep or require.

## Summary

Adds three independent verification jobs:

- `Dart Format`: checks formatting only for changed Dart files under `lib/` and `test/`
- `Generated Code Drift`: runs only when generator inputs changed, then runs `dart run build_runner build --delete-conflicting-outputs` and fails if `git diff --exit-code` finds generated changes
- `Dependency Review`: runs `actions/dependency-review-action@v4` on PRs and fails on newly introduced high/critical vulnerable dependencies

## Why

The existing CI already checks analyze, tests, Cloud Functions, Android build, and iOS build. These extra jobs are meant to catch different classes of mistakes:

- formatting drift in files touched by a PR
- generated files that were not committed after model/API/env changes
- risky dependency changes before merge

## What the first draft run showed

The first version checked all Dart files and all generated outputs. That was too broad for the current repo baseline:

- `Dart Format` tried to reformat 377 existing files
- `Generated Code Drift` found existing swagger/env generated output drift

This PR was tuned so unrelated PRs are not blocked by existing baseline debt:

- format now checks changed Dart files only
- generated drift now runs only when generator input files change

## Things to evaluate before merge

- Whether checking only changed Dart files is enough for contributor hygiene
- Whether the generated-input path list is broad enough
- Whether Dependency Review should stay at `fail-on-severity: high`
- Whether these checks should run on every push, PR only, or remain optional

## Verification

- `git diff --check` passed locally
- This draft PR itself is the real test run for the new checkers