### PR TITLE
fix: add awards to training comparison

### DIFF
--- a/lib/widgets/profile_check/profile_check.dart
+++ b/lib/widgets/profile_check/profile_check.dart
@@ -643,6 +643,8 @@ class ProfileAttackCheckWidgetState extends State<ProfileAttackCheckWidget> {
     Color enhancementColor = Colors.white;
     int cansComparison = 0;
     Color cansColor = Colors.orange;
+    int awardsComparison = 0;
+    Color awardsColor = Colors.orange;
     Color sslColor = Colors.green;
     bool sslProb = true;
     int ecstasy = 0;
@@ -708,6 +710,20 @@ class ProfileAttackCheckWidgetState extends State<ProfileAttackCheckWidget> {
         style: TextStyle(color: cansColor, fontSize: 11),
       );
 
+      // AWARDS
+      final int otherAwards = otherProfile.awards ?? 0;
+      final int myAwards = UserHelper.awards;
+      awardsComparison = otherAwards - myAwards;
+      if (awardsComparison < 0) {
+        awardsColor = Colors.green;
+      } else if (awardsComparison > 0) {
+        awardsColor = Colors.red;
+      }
+      final Text awardsText = Text(
+        "AWD",
+        style: TextStyle(color: awardsColor, fontSize: 11),
+      );
+
       /// SSL
       /// If (xan + esc) > 150, SSL is blank;
       /// if (esc + xan) < 150 & LSD < 50, SSL is green;
@@ -741,6 +757,8 @@ class ProfileAttackCheckWidgetState extends State<ProfileAttackCheckWidget> {
       additional.add(enhancementText);
       additional.add(const SizedBox(width: 5));
       additional.add(cansText);
+      additional.add(const SizedBox(width: 5));
+      additional.add(awardsText);
       additional.add(const SizedBox(width: 5));
       additional.add(sslWidget);
       additional.add(const SizedBox(width: 5));
@@ -906,6 +924,8 @@ class ProfileAttackCheckWidgetState extends State<ProfileAttackCheckWidget> {
                               otherLastActionRelative: otherProfile.lastActionRelative ?? '',
                               themeProvider: widget.themeProvider!,
                               estimatedStatsRange: estimatedStats,
+                              awardsCompare: awardsComparison,
+                              awardsColor: awardsColor,
                             ),
                             ffScouterStatsPayload:
                                 _settingsProvider.ffScouterEnabledStatus != 0 ? ffScouterStatsPayload : null,
@@ -1150,6 +1170,8 @@ class ProfileAttackCheckWidgetState extends State<ProfileAttackCheckWidget> {
                                   otherLastActionRelative: otherProfile.lastActionRelative ?? '',
                                   themeProvider: widget.themeProvider!,
                                   estimatedStatsRange: estimatedStats,
+                                  awardsCompare: awardsComparison,
+                                  awardsColor: awardsColor,
                                 );
 
                                 final ffScouterStatsPayload = FFScouterStatsPayload(targetId: otherProfile.id ?? 0);
@@ -1261,6 +1283,8 @@ class ProfileAttackCheckWidgetState extends State<ProfileAttackCheckWidget> {
                               otherLastActionRelative: otherProfile.lastActionRelative ?? '',
                               themeProvider: widget.themeProvider!,
                               estimatedStatsRange: estimatedStats,
+                              awardsCompare: awardsComparison,
+                              awardsColor: awardsColor,
                             );
 
                             final ffScouterStatsPayload = FFScouterStatsPayload(targetId: otherProfile.id ?? 0);

--- a/lib/widgets/stats/estimated_stats_dialog.dart
+++ b/lib/widgets/stats/estimated_stats_dialog.dart
@@ -107,6 +107,33 @@ class EstimatedStatsDialog extends StatelessWidget {
       ],
     );
 
+    Widget awardsWidget = const SizedBox.shrink();
+    if (estimatedStatsPayload.awardsCompare != null) {
+      String awardsRelative = "";
+      if (estimatedStatsPayload.awardsCompare! > 0) {
+        awardsRelative = "${estimatedStatsPayload.awardsCompare!.abs()} MORE than you";
+      } else if (estimatedStatsPayload.awardsCompare == 0) {
+        awardsRelative = "SAME as you";
+      } else {
+        awardsRelative = "${estimatedStatsPayload.awardsCompare!.abs()} LESS than you";
+      }
+
+      awardsWidget = Row(
+        children: [
+          const Text(
+            "> Awards: ",
+            style: TextStyle(fontSize: 14),
+          ),
+          Flexible(
+            child: Text(
+              awardsRelative,
+              style: TextStyle(color: estimatedStatsPayload.awardsColor, fontSize: 14),
+            ),
+          ),
+        ],
+      );
+    }
+
     final Widget sslWidget = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -207,6 +234,11 @@ class EstimatedStatsDialog extends StatelessWidget {
               padding: const EdgeInsets.only(top: 20, left: 4),
               child: cansWidget,
             ),
+            if (estimatedStatsPayload.awardsCompare != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 20, left: 4),
+                child: awardsWidget,
+              ),
             Padding(
               padding: const EdgeInsets.only(top: 20, left: 4),
               child: sslWidget,

--- a/lib/widgets/stats/stats_dialog.dart
+++ b/lib/widgets/stats/stats_dialog.dart
@@ -68,6 +68,8 @@ class EstimatedStatsPayload {
     required this.otherLastActionRelative,
     required this.themeProvider,
     this.estimatedStatsRange = '',
+    this.awardsCompare,
+    this.awardsColor,
   });
 
   final int xanaxCompare;
@@ -88,6 +90,8 @@ class EstimatedStatsPayload {
   final String otherLastActionRelative;
   final ThemeProvider themeProvider;
   final String estimatedStatsRange;
+  final int? awardsCompare;
+  final Color? awardsColor;
 }
 
 class FFScouterStatsPayload {


### PR DESCRIPTION
This follows up on #222 and keeps the scope to the two profile-check pieces we discussed.

What changed:
- adds an AWD indicator next to the existing profile-check comparison labels: XAN, RFL, ENH, CAN, SSL
- adds an optional Awards row in the Training Comparison dialog
- compares target awards against the current user awards using the same traffic-light idea: fewer than you is green, same is orange, more than you is red

Why:
Awards are already visible on the top of a profile, but adding them to the comparison area makes it easier to quickly spot targets who are behind or ahead on the awards curve while checking profiles.

I kept this limited to the profile-check / Training Comparison flow. I did not touch faction assist notifications or war/retal cards in this PR, because the clarified issue comments point specifically at Training Comparison.

Local verification:
- Ran git diff --check.

I could not run Flutter analyzer/build locally because flutter is not available on this PATH, so GitHub CI will be the compile check.