### PR TITLE
draft: add browser revive services menu

### DIFF
--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -82,6 +82,12 @@ import 'package:torn_pda/widgets/gym/steadfast_widget.dart';
 import 'package:torn_pda/widgets/jail/jail_widget.dart';
 import 'package:torn_pda/widgets/profile_check/profile_check.dart';
 import 'package:torn_pda/widgets/quick_items/quick_items_widget.dart';
+import 'package:torn_pda/widgets/revive/combat_ready_revive_button.dart';
+import 'package:torn_pda/widgets/revive/midnightx_revive_button.dart';
+import 'package:torn_pda/widgets/revive/nuke_revive_button.dart';
+import 'package:torn_pda/widgets/revive/uhc_revive_button.dart';
+import 'package:torn_pda/widgets/revive/wolverines_revive_button.dart';
+import 'package:torn_pda/widgets/revive/wtf_revive_button.dart';
 import "package:torn_pda/widgets/settings/userscripts_add_dialog.dart";
 import 'package:torn_pda/widgets/trades/trades_widget.dart';
 import 'package:torn_pda/widgets/vault/vault_widget.dart';
@@ -2880,6 +2886,7 @@ class WebViewFullState extends State<WebViewFull>
                 _crimesMenuIcon(),
                 _quickItemsMenuIcon(),
                 if (!_settingsProvider.removeTravelQuickReturnButton) _travelHomeIcon(),
+                _reviveServicesIcon(),
                 _vaultsPopUpIcon(),
                 _tradesMenuIcon(),
                 _vaultOptionsIcon(),
@@ -2952,6 +2959,62 @@ class WebViewFullState extends State<WebViewFull>
             ),
           )
         : const SizedBox.shrink();
+  }
+
+  Widget _reviveServicesIcon() {
+    final userStatus = UserHelper.basic?.status;
+    final inHospital = userStatus?.state == "Hospital";
+    if (!inHospital) return const SizedBox.shrink();
+
+    final warController = context.read<WarController>();
+    final services = <PopupMenuEntry<String>>[];
+
+    if (warController.nukeReviveActive) {
+      services.add(const PopupMenuItem(value: "nuke", child: Text("Nuke revive")));
+    }
+    if (warController.uhcReviveActive) {
+      services.add(const PopupMenuItem(value: "uhc", child: Text("UHC revive")));
+    }
+    if (warController.wtfReviveActive) {
+      services.add(const PopupMenuItem(value: "wtf", child: Text("WTF revive")));
+    }
+    if (warController.midnightXReviveActive) {
+      services.add(const PopupMenuItem(value: "midnight", child: Text("Midnight X revive")));
+    }
+    if (warController.wolverinesReviveActive) {
+      services.add(const PopupMenuItem(value: "wolverines", child: Text("The Wolverines revive")));
+    }
+    if (warController.combatReadyReviveActive) {
+      services.add(const PopupMenuItem(value: "combatReady", child: Text("Combat Ready revive")));
+    }
+
+    if (services.isEmpty) return const SizedBox.shrink();
+
+    return PopupMenuButton<String>(
+      icon: Icon(
+        Icons.medical_services_outlined,
+        color: _webViewProvider.bottomBarStyleEnabled ? _themeProvider.mainText : Colors.white,
+      ),
+      tooltip: "Revive services",
+      onSelected: (selection) {
+        _webViewProvider.verticalMenuClose();
+        switch (selection) {
+          case "nuke":
+            openNukeReviveDialog(context, _themeProvider, null);
+          case "uhc":
+            openUhcReviveDialog(context, _themeProvider, null);
+          case "wtf":
+            openWtfReviveDialog(context, _themeProvider, null);
+          case "midnight":
+            openMidnightXReviveDialog(context, _themeProvider, null);
+          case "wolverines":
+            openWolverinesReviveDialog(context, _themeProvider, null);
+          case "combatReady":
+            openCombatReadyReviveDialog(context, _themeProvider, null);
+        }
+      },
+      itemBuilder: (context) => services,
+    );
   }
 
   Future<void> _goBackOrForward(DragEndDetails details) async {


### PR DESCRIPTION
Draft PR for #90 so we can discuss the direction before polishing this further.

Hi @Manuito83, I wanted to check whether this matches what you had in mind for adding revive services to the browser.

What this draft tries:
- Adds a small revive-services menu icon to the browser app bar when the cached user status says the player is in Hospital.
- Reuses the existing enabled revive-service settings, so only active providers appear.
- Reuses the existing revive dialogs for Nuke, UHC, WTF, Midnight X, The Wolverines, and Combat Ready.
- Passes no profile object to those dialogs, so they fetch fresh profile data before sending a request. That keeps the existing safety check that blocks the request if Torn says the user is not hospitalized.

Why this approach:
I avoided injecting buttons into Torn's hospital/profile DOM because that would be more fragile. This keeps the feature inside Torn PDA's browser chrome and reuses the revive flows that already work from Profile/War.

Questions before this becomes a normal PR:
- Is the browser app bar the right place for this, or would you prefer the vertical tab/menu area or only the hospital page?
- Should the icon appear only when cached status says Hospital, or should it always be available and let the dialog do the fresh status check?
- Should HeLa stay omitted here, matching the current commented-out profile/war usage, or should it be included too?

Local verification:
- Ran git diff --check.

I could not run Flutter analyzer/build locally because flutter is not available on this PATH, so CI is the compile check.