### PR TITLE
docs: refresh userscript compatibility notes

### DIFF
--- a/docs/userscripts/gm-compatibility.md
+++ b/docs/userscripts/gm-compatibility.md
@@ -24,11 +24,11 @@ The `@grant` header specifies which GM_* and GM.* APIs the script needs access t
 **Currently supported:**
 - Header parsing and storage
 - Grant list is available in the UserScriptModel
+- Torn PDA includes a baseline GM compatibility handler for common `GM_*` and `GM.*` APIs
 
 **TODO:**
-- Implement actual GM_* API functionality
-- Add PDA_* API access
-- Implement ###PDA-APIKEY### replacement
+- Expand and test compatibility against a documented ViolentMonkey/TamperMonkey API matrix
+- Add any missing PDA-specific permission handling if Torn PDA starts enforcing grants
 
 ### @require
 
@@ -64,17 +64,17 @@ The `@match` header specifies which URLs the script should run on. Pattern match
 ```
 
 **Current implementation:**
-- Simple wildcard patterns (*)
-- Substring matching (e.g., `*torn.com*` matches `https://torn.com/`)
-- Case-insensitive matching
+- `*` as a universal match for backwards compatibility
+- Scheme wildcards such as `*://www.torn.com/*`
+- Domain wildcards such as `*://*.torn.com/*`
+- Path wildcards such as `*://www.torn.com/profiles.php*`
+- Legacy patterns without a protocol, such as `www.torn.com/*`
+- Fallback handling for non-standard legacy patterns
 
 **TODO:**
-- Implement full ViolentMonkey-style pattern matching
 - Add support for @exclude patterns
 - Add support for @include patterns
-- Add scheme wildcards (http://, https://, *)
-- Add domain wildcards (*.example.com)
-- Add path wildcards (/path/*)
+- Keep expanding edge-case coverage against the userscript manager specifications
 
 ## Version Matching
 
@@ -106,6 +106,7 @@ List<String> requires;    // List of @require headers
 - `toJson()` - Serializes grants and requires
 - `shouldInject()` - Improved pattern matching with URL normalization
 - `isNewerVersion()` - Uses VersionModel for better version comparison
+- `adaptSource()` in `UserScriptsProvider` replaces `###PDA-APIKEY###` at injection time
 
 ### ScriptHeaderModel
 
@@ -200,13 +201,11 @@ flutter test test/models/script_header_model_test.dart
 ## Future Work
 
 ### High Priority
-- Implement actual GM_* API functionality
 - Implement automatic loading of @require scripts
-- Add PDA_* API access
-- Implement ###PDA-APIKEY### replacement
+- Add a compatibility matrix for supported GM APIs and missing behavior
+- Add PDA-specific permission handling if grant enforcement is introduced
 
 ### Medium Priority
-- Full ViolentMonkey-style pattern matching
 - @exclude and @include pattern support
 - Script installation improvements
 - Update check improvements


### PR DESCRIPTION
Hi @Manuito83, this is the docs-only follow-up from the older userscript DX work in #289.

While checking what is still left there, I noticed the GM compatibility doc is a little stale: it still marks some behavior as TODO even though the current app already parses grants/requires, has improved @match handling, includes baseline GM handlers, and replaces ###PDA-APIKEY### at injection time.

This PR only updates the documentation to better reflect the current state. It does not change app behavior.

I kept the remaining TODOs explicit, especially @require loading, @include/@exclude, and a possible future compatibility matrix. Please let me know if any wording should be more conservative.