### PR TITLE
draft: add userscript @require loading

### DIFF
--- a/lib/models/userscript_model.dart
+++ b/lib/models/userscript_model.dart
@@ -38,6 +38,7 @@ class UserScriptModel {
     this.customApiKeyCandidate = false,
     this.grants = const [],
     this.requires = const [],
+    this.requiredSources = const [],
   });
 
   bool enabled;
@@ -54,6 +55,7 @@ class UserScriptModel {
   bool customApiKeyCandidate;
   List<String> grants;
   List<String> requires;
+  List<String> requiredSources;
 
   factory UserScriptModel.fromJson(Map<String, dynamic> json) {
     // First check if is old model
@@ -84,6 +86,7 @@ class UserScriptModel {
         isExample: isExample,
         grants: json["grants"] is List<dynamic> ? json["grants"].cast<String>() : [],
         requires: json["requires"] is List<dynamic> ? json["requires"].cast<String>() : [],
+        requiredSources: json["requiredSources"] is List<dynamic> ? json["requiredSources"].cast<String>() : [],
       );
     } else {
       return UserScriptModel(
@@ -101,6 +104,7 @@ class UserScriptModel {
         customApiKeyCandidate: json["customApiKeyCandidate"] ?? false,
         grants: json["grants"] is List<dynamic> ? json["grants"].cast<String>() : [],
         requires: json["requires"] is List<dynamic> ? json["requires"].cast<String>() : [],
+        requiredSources: json["requiredSources"] is List<dynamic> ? json["requiredSources"].cast<String>() : [],
       );
     }
   }
@@ -116,6 +120,7 @@ class UserScriptModel {
     String? customApiKey,
     bool? customApiKeyCandidate,
     bool? manuallyEdited,
+    List<String>? requiredSources,
   }) {
     if (metaMap["name"] == null) {
       throw Exception("No script name found in userscript");
@@ -138,6 +143,7 @@ class UserScriptModel {
       customApiKeyCandidate: customApiKeyCandidate ?? false,
       grants: metaMap["grants"] ?? [],
       requires: metaMap["requires"] ?? [],
+      requiredSources: requiredSources ?? [],
     );
   }
 
@@ -146,6 +152,7 @@ class UserScriptModel {
       final response = await http.get(Uri.parse(url));
       if (response.statusCode == 200) {
         final metaMap = UserScriptModel.parseHeader(response.body);
+        final requiredSources = await fetchRequiredSources((metaMap["requires"] as List<String>?) ?? []);
         return (
           success: true,
           message: "Success",
@@ -155,6 +162,7 @@ class UserScriptModel {
             updateStatus: UserScriptUpdateStatus.upToDate,
             isExample: isExample ?? false,
             manuallyEdited: false, // Not manually edited if loaded from URL
+            requiredSources: requiredSources,
           ),
         );
       } else {
@@ -211,7 +219,33 @@ class UserScriptModel {
         "customApiKeyCandidate": customApiKeyCandidate,
         "grants": grants,
         "requires": requires,
+        "requiredSources": requiredSources,
       };
+
+  String get sourceWithRequires {
+    if (requiredSources.isEmpty) return source;
+    return "${requiredSources.join("\n;\n")}\n;\n$source";
+  }
+
+  static Future<List<String>> fetchRequiredSources(List<String> requires) async {
+    final sources = <String>[];
+
+    for (final requireUrl in requires.where((url) => url.trim().isNotEmpty)) {
+      final uri = Uri.parse(requireUrl.trim());
+      if (uri.scheme != "https" && uri.scheme != "http") {
+        throw Exception("Unsupported @require URL: $requireUrl");
+      }
+
+      final response = await http.get(uri);
+      if (response.statusCode != 200) {
+        throw Exception("@require failed for $requireUrl with status ${response.statusCode}");
+      }
+
+      sources.add(response.body);
+    }
+
+    return sources;
+  }
 
   static Map<String, dynamic> parseHeader(String source) {
     // Thanks to [ViolentMonkey](https://github.com/violentmonkey/violentmonkey) for the following two regexes
@@ -353,6 +387,7 @@ class UserScriptModel {
     String? url,
     String? customApiKey,
     bool? customApiKeyCandidate,
+    List<String>? requiredSources,
     required UserScriptUpdateStatus updateStatus,
   }) {
     if (source != null) {
@@ -374,6 +409,8 @@ class UserScriptModel {
         if (metaMap["downloadURL"] != null) {
           this.url = metaMap["downloadURL"];
         }
+        grants = metaMap["grants"] ?? grants;
+        requires = metaMap["requires"] ?? requires;
       } catch (e) {
         // Do nothing
       }
@@ -404,6 +441,9 @@ class UserScriptModel {
     }
     if (customApiKeyCandidate != null) {
       this.customApiKeyCandidate = customApiKeyCandidate;
+    }
+    if (requiredSources != null) {
+      this.requiredSources = requiredSources;
     }
     this.updateStatus = updateStatus;
   }

--- a/lib/providers/userscripts_provider.dart
+++ b/lib/providers/userscripts_provider.dart
@@ -171,7 +171,7 @@ class UserScriptsProvider extends ChangeNotifier {
                 injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
                 // If the script is a custom API key script, we need to replace the API key
                 source: adaptSource(
-                  source: s.source,
+                  source: s.sourceWithRequires,
                   scriptFinalApiKey: s.customApiKey.isNotEmpty ? s.customApiKey : pdaApiKey,
                 ),
               );
@@ -233,6 +233,7 @@ class UserScriptsProvider extends ChangeNotifier {
     List<String>? matches,
     String? customApiKey,
     bool? customApiKeyCandidate,
+    List<String>? requiredSources,
   }) async {
     _invalidateGlobalDisable();
     final newScript = UserScriptModel(
@@ -248,6 +249,7 @@ class UserScriptsProvider extends ChangeNotifier {
       isExample: isExample,
       customApiKey: customApiKey ?? "",
       customApiKeyCandidate: customApiKeyCandidate ?? false,
+      requiredSources: requiredSources ?? [],
     );
 
     if (_addScript(_userScriptList, newScript, "addUserScript")) {
@@ -267,6 +269,7 @@ class UserScriptsProvider extends ChangeNotifier {
     required bool isFromRemote,
     required String? customApiKey,
     required bool? customApiKeyCandidate,
+    List<String>? requiredSources,
   }) {
     _invalidateGlobalDisable();
     List<String>? matches;
@@ -284,6 +287,7 @@ class UserScriptsProvider extends ChangeNotifier {
           manuallyEdited: manuallyEdited,
           customApiKey: customApiKey ?? "",
           customApiKeyCandidate: customApiKeyCandidate ?? false,
+          requiredSources: requiredSources,
           matches: matches,
           updateStatus: () {
             // If the script comes from remote

--- a/lib/widgets/settings/userscripts_add_dialog.dart
+++ b/lib/widgets/settings/userscripts_add_dialog.dart
@@ -742,6 +742,7 @@ class UserScriptsAddDialogState extends State<UserScriptsAddDialog> with TickerP
                                 isFromRemote: true, // isFromRemote
                                 customApiKey: _customApiKey,
                                 customApiKeyCandidate: _isCurrentScriptCandidateForCustomApiKey,
+                                requiredSources: _fetchedRemoteModel!.requiredSources,
                               );
 
                               BotToast.showText(
@@ -777,6 +778,8 @@ class UserScriptsAddDialogState extends State<UserScriptsAddDialog> with TickerP
       final inputName = _addNameController.text;
       final inputTime = _originalTime;
       final inputSource = _addSourceController.text;
+      Map<String, dynamic>? metaMap;
+      List<String> requiredSources = const [];
 
       _isCurrentScriptCandidateForCustomApiKey = inputSource.contains(pdaKeyWord);
 
@@ -789,12 +792,34 @@ class UserScriptsAddDialogState extends State<UserScriptsAddDialog> with TickerP
         return;
       }
 
+      try {
+        metaMap = UserScriptModel.parseHeader(inputSource);
+        requiredSources = await _fetchRequiredSourcesForSave(metaMap);
+      } on Exception catch (e) {
+        if (e.toString().contains("No header found")) {
+          metaMap = null;
+        } else {
+          BotToast.showText(
+            align: const Alignment(0, 0),
+            clickClose: true,
+            text: "Error saving script: $e",
+            textStyle: const TextStyle(fontSize: 14, color: Colors.white),
+            contentColor: Colors.orange[800]!,
+            duration: const Duration(seconds: 4),
+            contentPadding: const EdgeInsets.all(10),
+          );
+          return;
+        }
+      }
+
       Navigator.of(context).pop();
 
       // This is a new script
       if (!widget.editingExistingScript) {
         try {
-          final metaMap = UserScriptModel.parseHeader(inputSource);
+          if (metaMap == null) {
+            throw Exception("No header found in userscript.");
+          }
           _userScriptsProvider.addUserScriptByModel(
             UserScriptModel.fromMetaMap(
               metaMap,
@@ -803,6 +828,7 @@ class UserScriptsAddDialogState extends State<UserScriptsAddDialog> with TickerP
               time: inputTime,
               customApiKey: _customApiKey,
               customApiKeyCandidate: _isCurrentScriptCandidateForCustomApiKey,
+              requiredSources: requiredSources,
             ),
           );
         } on Exception catch (e) {
@@ -861,6 +887,7 @@ class UserScriptsAddDialogState extends State<UserScriptsAddDialog> with TickerP
           isFromRemote: false,
           customApiKey: _customApiKey,
           customApiKeyCandidate: _isCurrentScriptCandidateForCustomApiKey,
+          requiredSources: requiredSources,
         );
         if (!couldParseHeader) {
           BotToast.showText(
@@ -877,6 +904,12 @@ class UserScriptsAddDialogState extends State<UserScriptsAddDialog> with TickerP
       _isCurrentScriptCandidateForCustomApiKey = false;
       _showCustomApiKeyButton = false;
     }
+  }
+
+  Future<List<String>> _fetchRequiredSourcesForSave(Map<String, dynamic> metaMap) async {
+    final requires = (metaMap["requires"] as List<String>?) ?? const <String>[];
+    if (requires.isEmpty) return const [];
+    return UserScriptModel.fetchRequiredSources(requires);
   }
 
   void _saveScriptWithoutApiKeyWarning() {

--- a/test/models/userscript_model_test.dart
+++ b/test/models/userscript_model_test.dart
@@ -260,6 +260,7 @@ void main() {
         isExample: false,
         customApiKey: 'testkey',
         customApiKeyCandidate: true,
+        requiredSources: ['window.requiredLoaded = true;'],
       );
 
       final json = original.toJson();
@@ -273,6 +274,36 @@ void main() {
       expect(restored.isExample, original.isExample);
       expect(restored.customApiKey, original.customApiKey);
       expect(restored.customApiKeyCandidate, original.customApiKeyCandidate);
+      expect(restored.requiredSources, original.requiredSources);
+    });
+
+    test('sourceWithRequires prepends fetched dependencies in order', () {
+      final model = UserScriptModel(
+        name: 'With Requires',
+        source: 'window.mainLoaded = true;',
+        requiredSources: [
+          'window.firstRequired = true;',
+          'window.secondRequired = true;',
+        ],
+        isExample: false,
+      );
+
+      expect(
+        model.sourceWithRequires,
+        'window.firstRequired = true;\n;\n'
+        'window.secondRequired = true;\n;\n'
+        'window.mainLoaded = true;',
+      );
+    });
+
+    test('sourceWithRequires returns original source when no dependencies are cached', () {
+      final model = UserScriptModel(
+        name: 'Without Requires',
+        source: 'window.mainLoaded = true;',
+        isExample: false,
+      );
+
+      expect(model.sourceWithRequires, 'window.mainLoaded = true;');
     });
   });
 }


### PR DESCRIPTION
Hi @Manuito83, opening this one as a draft because @require support changes how third-party code is loaded and injected. I would like your opinion before treating it as ready.

This is a conservative first pass from the older DX/userscript compatibility work in #289. Instead of fetching dependencies during every page load, it resolves @require URLs when a script is added or updated, stores the fetched dependency source with the userscript model, and prepends those dependencies before the main script during injection.

What changed:
- stores fetched @require sources alongside the parsed @require URLs
- resolves @require dependencies for remote scripts during fetch/load
- resolves @require dependencies for manually pasted scripts before saving
- injects cached required sources before the userscript source
- preserves cached required sources through JSON backup/restore
- adds small tests for source ordering and serialization

Questions before this should be considered mergeable:
- Is caching dependency source in the userscript model acceptable, or would you prefer resolving on every update/check only?
- Should @require be limited to HTTPS only? I currently allow both http and https, but I can restrict it if you prefer.
- If one dependency fails to load, should the app reject the save as it does here, or save the script but disable it / warn only?

I kept this separate from the safer grant-warning/docs/test PRs because the review surface and risk are higher.