### PR TITLE
draft: refresh generator dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   device_info_plus: 11.5.0
   easy_rich_text: 2.2.0
   encrypt_shared_preferences: 0.9.10
-  envied: 1.2.1
+  envied: ^1.3.4
   expandable: 5.0.1
   file_picker: 10.3.1
   file_saver: 0.3.1
@@ -79,10 +79,10 @@ dependencies:
       ref: 85c37faa6cc62cd237264a82602eafd4eef937b1
       path: packages/home_widget
   html: 0.15.6
-  http: 1.5.0
+  http: ^1.6.0
   internet_connection_checker_plus: 2.7.2
   intl: 0.20.2
-  json_annotation: 4.9.0 # Used by swagger_dart_code_generator
+  json_annotation: ^4.11.0 # Used by swagger_dart_code_generator
   lints: 6.0.0
   flutter_material_design_icons: 1.1.7447
   path_provider: 2.1.5
@@ -141,16 +141,16 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.7.1
   # Used by swagger_dart_code_generator
-  chopper_generator: 8.4.0 
-  envied_generator: 1.3.0
+  chopper_generator: ^8.6.2
+  envied_generator: ^1.3.4
   flutter_launcher_icons: 0.14.4
   flutter_test:
     sdk: flutter
   # Used by swagger_dart_code_generator
-  json_serializable: 6.11.1 
+  json_serializable: ^6.13.2
   ## flutter pub run import_sorter:main
   import_sorter: 5.0.0-releasecandidate.1
-  swagger_dart_code_generator: 4.0.0
+  swagger_dart_code_generator: ^4.1.1
 
 flutter_icons:
   android: true


### PR DESCRIPTION
Hi @Manuito83, opening this as a draft dependency-update PR so CI can tell us how safe this batch is.

This first batch focuses on the generated-code/tooling stack rather than broad runtime packages. It updates:
- envied / envied_generator
- json_annotation / json_serializable
- chopper_generator
- swagger_dart_code_generator
- http, because the newer chopper_generator stack requires http ^1.6.0

Local checks:
- flutter test passed in Docker
- git diff --check passed
- local flutter analyze was started in Docker, but it stayed silent for several minutes after starting with the newer analyzer stack, so I stopped the container and am leaving this draft for GitHub CI to validate on a clean runner.

I intentionally did not include Firebase, WebView, auth/sign-in, file picker, notifications, or other higher-risk platform/runtime packages in this PR.