### PR TITLE
Android: fix travel live update tracker direction and stale-session arrival notification

### DIFF
--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/AndroidLiveUpdateAdapter.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/AndroidLiveUpdateAdapter.kt
@@ -108,10 +108,15 @@ class AndroidTravelLiveUpdateAdapter(
     }
 
     private fun clearState(sessionId: String) {
+        // Alarms outlive this adapter: they are keyed by a sessionId persisted in
+        // SharedPreferences, while activeSessionId is process memory and is null after the
+        // engine is recreated mid-trip. Guarding the cancellation on it stranded the
+        // ARRIVED/REFRESH alarms of the previous session, which then posted a second,
+        // independent notification under the old id once a new session had started.
+        TravelLiveUpdateRefreshScheduler.cancelRefresh(context, sessionId)
+        TravelLiveUpdateRefreshScheduler.cancelArrived(context, sessionId)
         if (sessionId == activeSessionId) {
             updateJob?.cancel()
-            TravelLiveUpdateRefreshScheduler.cancelRefresh(context, sessionId)
-            TravelLiveUpdateRefreshScheduler.cancelArrived(context, sessionId)
             cachedPayload = null
             activeSessionId = null
         }

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationReceiver.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/LiveUpdateNotificationReceiver.kt
@@ -186,7 +186,7 @@ class LiveUpdateNotificationReceiver : BroadcastReceiver() {
             PendingIntent.getActivity(context, 0, it, PendingIntent.FLAG_IMMUTABLE)
         }
 
-        val destinationIcon = TravelLiveUpdateAssets.trackerIconFor(destination)
+        val notificationIcon = TravelLiveUpdateAssets.notificationIcon()
         val timeFormat = android.text.format.DateFormat.getTimeFormat(context)
         val nowFormatted = timeFormat.format(java.util.Date())
 
@@ -209,7 +209,7 @@ class LiveUpdateNotificationReceiver : BroadcastReceiver() {
         }
 
         val builder = androidx.core.app.NotificationCompat.Builder(context, channelId)
-            .setSmallIcon(destinationIcon)
+            .setSmallIcon(notificationIcon)
             .setContentTitle(arrivedTitle)
             .setContentText(arrivedContentText)
             .setContentIntent(tapIntent)

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssets.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssets.kt
@@ -4,6 +4,8 @@ import com.manuito.tornpda.R
 
 object TravelLiveUpdateAssets {
 
+    fun notificationIcon(): Int = R.drawable.notification_travel
+
     fun flagIconFor(displayName: String?): Int {
         return when (displayName?.trim()?.lowercase()) {
             "torn" -> R.drawable.action_torn
@@ -20,14 +22,9 @@ object TravelLiveUpdateAssets {
             "switzerland" -> R.drawable.flag_switzerland
             "uae", "united arab emirates" -> R.drawable.flag_uae
             "united kingdom", "uk" -> R.drawable.flag_uk
-            else -> R.drawable.plane_right
+            else -> R.drawable.action_travel
         }
     }
 
-    fun trackerIconFor(destinationDisplayName: String?): Int {
-        return when (destinationDisplayName?.trim()?.lowercase()) {
-            "torn" -> R.drawable.plane_left
-            else -> R.drawable.plane_right
-        }
-    }
+    fun trackerIconFor(): Int = R.drawable.plane_right
 }

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
@@ -65,13 +65,13 @@ class TravelLiveUpdateNotificationFactory(
         dismissIntent: android.app.PendingIntent,
     ): Notification {
         val hasActuallyArrived = contentBuilder.hasActuallyArrived(payload)
-        val destinationIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
+        val notificationIcon = TravelLiveUpdateAssets.notificationIcon()
         val remainingText = formatRemaining(payload)
         val earliestReturnText = formatEarliestReturn(payload)
         val arrivalClockTime = formatArrivalClockTime(payload)
 
         val builder = NotificationCompat.Builder(context, channelId)
-            .setSmallIcon(destinationIcon)
+            .setSmallIcon(notificationIcon)
             .setContentIntent(tapIntent)
             .setDeleteIntent(dismissIntent)
             .setOnlyAlertOnce(true)
@@ -152,13 +152,13 @@ class TravelLiveUpdateNotificationFactory(
         dismissIntent: android.app.PendingIntent,
     ): Notification {
         val hasActuallyArrived = contentBuilder.hasActuallyArrived(payload)
-        val destinationIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
+        val notificationIcon = TravelLiveUpdateAssets.notificationIcon()
         val remainingText = formatRemaining(payload)
         val earliestReturnText = formatEarliestReturn(payload)
         val arrivalClockTime = formatArrivalClockTime(payload)
 
         val builder = Notification.Builder(context, channelId)
-            .setSmallIcon(destinationIcon)
+            .setSmallIcon(notificationIcon)
             .setContentIntent(tapIntent)
             .setDeleteIntent(dismissIntent)
             .setOnlyAlertOnce(true)
@@ -316,7 +316,7 @@ class TravelLiveUpdateNotificationFactory(
         val elapsed = progress.elapsedSeconds.toInt().coerceIn(0, total)
         val originIcon = TravelLiveUpdateAssets.flagIconFor(payload.originDisplayName)
         val destinationIcon = TravelLiveUpdateAssets.flagIconFor(payload.currentDestinationDisplayName)
-        val trackerIcon = TravelLiveUpdateAssets.trackerIconFor(payload.currentDestinationDisplayName)
+        val trackerIcon = TravelLiveUpdateAssets.trackerIconFor()
 
         return try {
             val style = refs.styleCtor.newInstance()

--- a/android/app/src/test/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssetsTest.kt
+++ b/android/app/src/test/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateAssetsTest.kt
@@ -29,13 +29,30 @@ class TravelLiveUpdateAssetsTest {
         val unknown = TravelLiveUpdateAssets.flagIconFor("Atlantis")
         val mexico = TravelLiveUpdateAssets.flagIconFor("Mexico")
         assertNotEquals(mexico, unknown)
+        assertNotEquals("unknown endpoints must not render as a plane", TravelLiveUpdateAssets.trackerIconFor(), unknown)
     }
 
     @Test
-    fun trackerIconFlipsForHomewardTrip() {
+    fun contextualOriginsDoNotRenderAsTrackerPlane() {
         assertNotEquals(
-            TravelLiveUpdateAssets.trackerIconFor("Mexico"),
-            TravelLiveUpdateAssets.trackerIconFor("Torn"),
+            TravelLiveUpdateAssets.trackerIconFor(),
+            TravelLiveUpdateAssets.flagIconFor("Abroad"),
+        )
+        assertNotEquals(
+            TravelLiveUpdateAssets.trackerIconFor(),
+            TravelLiveUpdateAssets.flagIconFor("Hospital"),
+        )
+        assertNotEquals(
+            TravelLiveUpdateAssets.trackerIconFor(),
+            TravelLiveUpdateAssets.flagIconFor("Torn"),
+        )
+    }
+
+    @Test
+    fun notificationIconDoesNotRenderAsTrackerPlane() {
+        assertNotEquals(
+            TravelLiveUpdateAssets.trackerIconFor(),
+            TravelLiveUpdateAssets.notificationIcon(),
         )
     }
 }


### PR DESCRIPTION
Two independent fixes to the Android travel live update.

### 1. The tracker plane points backwards on return flights

`Notification.ProgressStyle` always fills left to right, with the origin icon at the start and the destination icon at the end, so the tracker should always face right. `trackerIconFor()` returned `plane_left` whenever the destination was Torn, which made the plane fly tail-first for the whole return leg.

`trackerIconFor()` now takes no argument and always returns `plane_right`.

While in there, two related icon nits:
- `flagIconFor()` fell back to `plane_right` for unknown endpoints, so a plane could render in the start/end slots and read as a second tracker. `Abroad` and `Hospital` now map to `action_travel` and `hospital`, and the fallback is `action_travel`.
- The small icon was the same plane drawable as the tracker. Added `notificationIcon()` returning `notification_travel`, matching the other travel notifications.

### 2. A stale session can post a second arrival notification

The `ARRIVED` and `REFRESH` alarms are keyed by a `sessionId` persisted in SharedPreferences and survive process death, but `clearState()` only cancelled them when the id matched `activeSessionId` — which is process memory and is null after the engine is recreated mid-trip.

So: engine restart mid-trip, then any end path cancels the notification and wipes the stored session while leaving the alarms armed. The next trip mints a fresh `sessionId`, and the stranded `ARRIVED` alarm later posts a second, independent notification under the old id, naming the previous destination.

The alarms are now cancelled unconditionally for the session being cleared; only the in-memory state stays behind the `activeSessionId` guard. Request codes are per-session (`sessionId.hashCode() + N`), so this cannot touch a live session's alarms.

### Testing

`./gradlew :app:testDebugUnitTest` — 43/43 pass, including 5 in `TravelLiveUpdateAssetsTest` extended to pin the tracker direction and keep the tracker, endpoint and small icons distinct.

No Dart changes.