### PR TITLE
Android hardening: remove API key from notification extras + guard early init in main()

### DIFF
--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/RacingLiveUpdateNotificationFactory.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/RacingLiveUpdateNotificationFactory.kt
@@ -381,6 +381,10 @@ class RacingLiveUpdateNotificationFactory(
     private fun LiveUpdatePayload.toExtrasBundle(): android.os.Bundle {
         return android.os.Bundle().also { bundle ->
             extras.forEach { (key, value) ->
+                // Notification extras are readable by any app holding
+                // notification-listener access, so the API key must never
+                // be included (it travels only in our own alarm intents)
+                if (key == "apiKey") return@forEach
                 when (value) {
                     is String -> bundle.putString(key, value)
                     is Boolean -> bundle.putBoolean(key, value)

--- a/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
+++ b/android/app/src/main/java/com/manuito/tornpda/liveupdates/TravelLiveUpdateNotificationFactory.kt
@@ -429,6 +429,10 @@ class TravelLiveUpdateNotificationFactory(
     private fun LiveUpdatePayload.toExtrasBundle(): android.os.Bundle {
         return android.os.Bundle().also { bundle ->
             extras.forEach { (key, value) ->
+                // Notification extras are readable by any app holding
+                // notification-listener access, so the API key must never
+                // be included (it travels only in our own alarm intents)
+                if (key == "apiKey") return@forEach
                 when (value) {
                     is String -> bundle.putString(key, value)
                     is Boolean -> bundle.putBoolean(key, value)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,7 +177,12 @@ Future<void> main() async {
   await drainFcmInbox();
 
   // Sync background-safe preferences
-  await Prefs().syncBackgroundPrefs();
+  try {
+    await Prefs().syncBackgroundPrefs();
+  } catch (e, stackTrace) {
+    log("Error syncing background prefs: $e");
+    logErrorToCrashlytics("Error syncing background prefs", "Background prefs sync failed: $e", stackTrace);
+  }
 
   // Core initialization
   await _initializeAppCompilation();
@@ -532,19 +537,24 @@ class MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
 /// Initialize app compilation and detect updates
 Future<void> _initializeAppCompilation() async {
-  final String currentCompilation = Platform.isAndroid ? androidCompilation : iosCompilation;
-  String lastSavedAppCompilation = await Prefs().getAppCompilation();
+  try {
+    final String currentCompilation = Platform.isAndroid ? androidCompilation : iosCompilation;
+    String lastSavedAppCompilation = await Prefs().getAppCompilation();
 
-  if (lastSavedAppCompilation.isNotEmpty && lastSavedAppCompilation != currentCompilation) {
-    // App has been updated
-    appHasBeenUpdated = true;
-    log("📜 App updated: $lastSavedAppCompilation → $currentCompilation");
-    await Prefs().setAppCompilation(currentCompilation);
-  } else if (lastSavedAppCompilation.isEmpty) {
-    // First app run
-    appIsFirstRun = true;
-    await Prefs().setAppCompilation(currentCompilation);
-    log("📜 First app run, saved compilation: $currentCompilation");
+    if (lastSavedAppCompilation.isNotEmpty && lastSavedAppCompilation != currentCompilation) {
+      // App has been updated
+      appHasBeenUpdated = true;
+      log("📜 App updated: $lastSavedAppCompilation → $currentCompilation");
+      await Prefs().setAppCompilation(currentCompilation);
+    } else if (lastSavedAppCompilation.isEmpty) {
+      // First app run
+      appIsFirstRun = true;
+      await Prefs().setAppCompilation(currentCompilation);
+      log("📜 First app run, saved compilation: $currentCompilation");
+    }
+  } catch (e, stackTrace) {
+    log("Error initializing app compilation: $e");
+    logErrorToCrashlytics("Error initializing app compilation", "App compilation initialization failed: $e", stackTrace);
   }
 }
 
@@ -798,6 +808,9 @@ Future<void> _initializeFirebase() async {
 
       FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
     }
+
+    // Report any errors stashed before Crashlytics was available
+    _flushPreFirebaseErrors();
   } catch (e) {
     log("Error initializing Firebase: $e");
     _isFirebaseInitialized = false;
@@ -910,14 +923,30 @@ void logToUser(String? message, {int duration = 3, Color? textColor, Color? back
   }
 }
 
+/// Errors caught before Crashlytics is available are stashed here and reported
+/// as soon as Firebase initializes, so early-init failures remain visible
+final List<(String, dynamic, StackTrace?)> _preFirebaseErrors = [];
+
 void logErrorToCrashlytics(String message, dynamic error, StackTrace? stackTrace) {
-  if (!Platform.isWindows && _isFirebaseInitialized) {
+  if (Platform.isWindows) return;
+  if (_isFirebaseInitialized) {
     try {
       FirebaseCrashlytics.instance.log(message);
       FirebaseCrashlytics.instance.recordError(error, stackTrace);
     } catch (e) {
       log("Failed to log to Crashlytics: $e");
     }
+  } else if (_preFirebaseErrors.length < 20) {
+    _preFirebaseErrors.add((message, error, stackTrace));
+  }
+}
+
+void _flushPreFirebaseErrors() {
+  if (_preFirebaseErrors.isEmpty) return;
+  final pending = List.of(_preFirebaseErrors);
+  _preFirebaseErrors.clear();
+  for (final (message, error, stackTrace) in pending) {
+    logErrorToCrashlytics(message, error, stackTrace);
   }
 }
 


### PR DESCRIPTION
This PR bundles two small Android robustness fixes found during a code review of `develop`.

## 1. Never expose the Torn API key in live update notification extras

`RacingLiveUpdateNotificationFactory.toExtrasBundle()` serialized the whole payload — including `apiKey` — into the posted notification via `setExtras()`. `Notification.extras` is readable by any app holding notification-listener access (watch companions, "cleaner" apps, potentially malware), so while a racing live update was active, the user's plaintext API key was exposed system-wide.

The key is only needed by the refresh chain, which carries it in the alarm `PendingIntent` extras (explicit intent to our own non-exported receiver, `FLAG_IMMUTABLE`) — the notification itself never reads it back, so filtering it out has no functional impact. The same filter is applied to the travel factory defensively (its payload currently carries no key, but a future payload change should not reintroduce the leak).

## 2. Guard the two unguarded early init steps in `main()`

All init steps in `main()` are individually wrapped in try/catch **except** `Prefs().syncBackgroundPrefs()` and `_initializeAppCompilation()`. Both run *before* `_initializeFirebase()` installs the error handlers, and both can genuinely throw:

- `syncBackgroundPrefs()` issues raw `SharedPreferencesAsync` platform-channel writes with no internal error handling;
- `_initializeAppCompilation()` hits the sembast **setters** on the first-run/after-update path, and unlike the getters (which swallow and return defaults), the setters and the DB open rethrow.

An exception there aborts `main()` before `runApp()`: the user gets a permanent black screen and nothing ever reaches Crashlytics — and the throwing path is hit exactly by the first-run/after-update population. With the guards, the app starts degraded (defaults, no changelog dialog) instead of dying blind.

Additionally, `logErrorToCrashlytics()` now stashes errors reported before Firebase is ready (capped at 20) and flushes them right after Crashlytics initializes, so these early failures — including the ones already logged by `_initializePlatformSpecifics()` / `_initializeBackupAndTheme()` — become visible in telemetry instead of being silently dropped.

## Verification

- `flutter analyze`: no issues
- `:app:compileDebugKotlin`: BUILD SUCCESSFUL
- Verified the racing refresh chain end-to-end: state lives exclusively in the alarm intent extras (`LiveUpdateNotificationReceiver` rebuilds the payload from `intent.extras`), nothing reads `Notification.extras` back, so removing the key from the notification cannot break refresh/arrived flows.