### PR TITLE
Fix GM handler crashes and script loss after renderer recovery

### DIFF
--- a/lib/utils/js_snippets/js_handlers.dart
+++ b/lib/utils/js_snippets/js_handlers.dart
@@ -115,12 +115,13 @@ String handler_GM() {
       function a(e, t) {
         if (!e) throw new TypeError("No key supplied to GM_getValue");
         try {
-          const r = i.getItem(e);
-          return "string" != typeof r
-            ? t
-            : r.startsWith("GMV2_")
-              ? (JSON.parse(r.slice(5)) ?? t)
-              : (r ?? t);
+          const r = i ? i.getItem(e) : null;
+          if ("string" != typeof r) return t;
+          if (!r.startsWith("GMV2_")) return r ?? t;
+          const json = r.slice(5);
+          // Guard against "GMV2_undefined" written by a buggy GM_setValue call
+          if (json === "undefined") return t;
+          return (JSON.parse(json) ?? t);
         } catch (e) {
           return (console.error(e), t);
         }
@@ -138,17 +139,23 @@ String handler_GM() {
       }
       function u(e, t) {
         if (!e) throw new TypeError("No key supplied to GM_setValue");
-        i.setItem(e, "GMV2_" + JSON.stringify(t));
+        if (!i) return;
+        // JSON.stringify(undefined) returns the JS value undefined (not the string),
+        // which string-concatenates to "GMV2_undefined" — unreadable by JSON.parse.
+        // Treat that the same as deleting the key.
+        const serialized = JSON.stringify(t);
+        if (serialized === undefined) { i.removeItem(e); return; }
+        i.setItem(e, "GMV2_" + serialized);
       }
       function l(e) {
         for (const [r, o] of t.entries(e)) u(r, o);
       }
       function d(e) {
         if (!e) throw new TypeError("No key supplied to GM_deleteValue");
-        i.removeItem(e);
+        i?.removeItem(e);
       }
       function f() {
-        return t.keys(i);
+        return i ? t.keys(i) : [];
       }
       function p(e) {
         if (!e || "string" != typeof e) return;
@@ -314,6 +321,11 @@ String handler_GM() {
           configurable: !1,
         });
       });
-    })(window, Object, DOMException, AbortController, Promise, localStorage);
+    })(window, Object, DOMException, AbortController, Promise,
+       // Safe-capture localStorage: accessing it throws SecurityError in some
+       // contexts (restrictive iframes, private-mode storage blocked, etc.).
+       // Passing null lets the GM functions degrade gracefully instead of
+       // aborting the entire IIFE and leaving GM/GM_getValue/... undefined.
+       (() => { try { return localStorage; } catch (_) { return null; } })());
   ''';
 }

--- a/lib/widgets/webviews/webview_full.dart
+++ b/lib/widgets/webviews/webview_full.dart
@@ -1513,6 +1513,35 @@ class WebViewFullState extends State<WebViewFull>
               _revertTransparentBackground();
             }
 
+            // Fallback: re-register scripts when they were wiped (browser close,
+            // renderer crash) and the reload doesn't trigger shouldOverrideUrlLoading.
+            // _handlersInjected is false in both removeAllUserScripts() and
+            // onRenderProcessGone/onWebContentProcessDidTerminate, so this catches all cases.
+            if (!_handlersInjected &&
+                uri != null &&
+                (Platform.isAndroid || ((Platform.isIOS || Platform.isWindows) && widget.windowId == null))) {
+              try {
+                await _ensureHandlersInjected();
+                final fallbackScripts = _userScriptsProvider.getCondSources(
+                  url: uri.toString(),
+                  pdaApiKey: UserHelper.apiKey,
+                  time: UserScriptTime.start,
+                );
+                await _addUserScriptsAvoidDuplicates(fallbackScripts);
+                // Evaluate inline for the current page since AT_DOCUMENT_START
+                // injection may already have been scheduled before the scripts
+                // were re-registered above.
+                for (final h in _userScriptsProvider.getHandlerSources(apiKey: UserHelper.apiKey, tabUid: _tabUid)) {
+                  await c.evaluateJavascript(source: h.source);
+                }
+                for (final s in fallbackScripts) {
+                  await c.evaluateJavascript(source: s.source);
+                }
+              } catch (e) {
+                log("⚠️ onLoadStart script fallback error: $e", name: "WEBVIEW FULL");
+              }
+            }
+
             try {
               _currentUrl = uri.toString();
 

--- a/userscripts/GMforPDA.user.js
+++ b/userscripts/GMforPDA.user.js
@@ -21,11 +21,13 @@
 	function __GM_getValue(key, defaultValue) {
 		if (!key) throw new TypeError("No key supplied to GM_getValue");
 		try {
-			const r = localStorage.getItem(key);
+			const r = localStorage ? localStorage.getItem(key) : null;
 			if (typeof r !== "string") return defaultValue;
-			if (r.startsWith("GMV2_"))
-				return JSON.parse(r.slice(5)) ?? defaultValue;
-			else return r ?? defaultValue;
+			if (!r.startsWith("GMV2_")) return r ?? defaultValue;
+			const json = r.slice(5);
+			// Guard against "GMV2_undefined" written by a buggy GM_setValue call
+			if (json === "undefined") return defaultValue;
+			return JSON.parse(json) ?? defaultValue;
 		} catch (e) {
 			console.error(e);
 			return defaultValue;
@@ -49,7 +51,13 @@
 	}
 	function __GM_setValue(key, value) {
 		if (!key) throw new TypeError("No key supplied to GM_setValue");
-		localStorage.setItem(key, "GMV2_" + JSON.stringify(value));
+		if (!localStorage) return;
+		// JSON.stringify(undefined) returns the JS value undefined (not the string),
+		// which string-concatenates to "GMV2_undefined" — unreadable by JSON.parse.
+		// Treat that the same as deleting the key.
+		const serialized = JSON.stringify(value);
+		if (serialized === undefined) { localStorage.removeItem(key); return; }
+		localStorage.setItem(key, "GMV2_" + serialized);
 	}
 	function __GM_setValues(values) {
 		for (const [key, value] of Object.entries(values)) {
@@ -58,7 +66,7 @@
 	}
 	function __GM_deleteValue(key) {
 		if (!key) throw new TypeError("No key supplied to GM_deleteValue");
-		localStorage.removeItem(key);
+		localStorage?.removeItem(key);
 	}
 	function __GM_deleteValues(keys) {
 		for (const key of keys) {
@@ -66,7 +74,7 @@
 		}
 	}
 	function __GM_listValues() {
-		return Object.keys(localStorage);
+		return localStorage ? Object.keys(localStorage) : [];
 	}
 	function __GM_addStyle(style) {
 		if (!style || typeof style !== "string") return;
@@ -244,4 +252,9 @@
 			});
 		return { abortController, prom };
 	}
-})(window, Object, DOMException, AbortController, Promise, localStorage);
+})(window, Object, DOMException, AbortController, Promise,
+   // Safe-capture localStorage: accessing it throws SecurityError in some
+   // contexts (restrictive iframes, private-mode storage blocked, etc.).
+   // Passing null lets the GM functions degrade gracefully instead of
+   // aborting the entire IIFE and leaving GM/GM_getValue/... undefined.
+   (() => { try { return localStorage; } catch (_) { return null; } })());


### PR DESCRIPTION
[I have done some testing on my local device with this build. The code and justifications seem to make sense to me. I would like to get your feedback about whether or not you think that this will solve the persistent userscript problems we're all seeing. What follows is an AI generated description of the problems and fixes.]

Two independent bugs that cause userscripts to silently lose access to GM globals (GM_getValue, GM_setValue, etc.) or fail to run at all after a page reload.

  Bug 1 — GM handler aborts on localStorage access in restricted contexts

  localStorage was accessed as a bare argument at IIFE invocation time. In certain page contexts (restrictive iframes, private mode, or security policies that block storage), this throws a SecurityError before the IIFE body runs at all,
  leaving GM, GM_getValue, GM_setValue, and every other exported global undefined for the rest of the page lifetime.

  Fix: wrap the localStorage capture in a try/catch so failure yields null instead of aborting the handler. All storage functions now null-check before use and degrade gracefully — reads return their default value, writes and deletes are
  no-ops.

  Also fixed a related serialisation bug: JSON.stringify(undefined) returns the JS undefined value (not a string), which string-concatenated to "GMV2_undefined" in storage. GM_getValue then called JSON.parse("undefined"), throwing
  SyntaxError: "undefined" is not valid JSON. GM_setValue now treats an unserializable value as a key deletion; GM_getValue adds an explicit guard for the "GMV2_undefined" sentinel.

  Both lib/utils/js_snippets/js_handlers.dart (the bundled runtime copy) and userscripts/GMforPDA.user.js (the readable source) are updated together — there is no automated build step between them.

  Bug 2 — Scripts not re-injected after renderer crash or background recovery

  When the renderer crashes, onRenderProcessGone/onWebContentProcessDidTerminate calls removeAllUserScripts() and sets _handlersInjected = false, then calls reload(). On Android, reload() does not trigger shouldOverrideUrlLoading — the
  only place _ensureHandlersInjected() was previously called — so the handler bundle and userscripts were never re-registered for the new page load.

  Fix: add a fallback at the top of onLoadStart: if _handlersInjected is false, re-register the handler bundle and start scripts via addUserScripts (for future loads) and evaluate them inline immediately (since AT_DOCUMENT_START scheduling
  may have already passed by the time onLoadStart fires). The _handlersInjected guard makes this a no-op on every subsequent normal navigation.

  ---
  Diagnosed and written by Claude Sonnet 4.6, reviewed and tested on-device by Jason Chu.